### PR TITLE
fix: #54 page size 9999→200 + #55 bare catch 加錯誤通知

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Custom Tag Preview v0.86 · 2026-05-18 22:09</title>
+    <title>Custom Tag Preview v0.86 · 2026-05-19 17:23</title>
     <script>
       // FOUC 防閃爍：在 Vue 掛載前同步注入 data-theme 與字型大小，避免先閃預設值
       (function () {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -12,7 +12,7 @@
   "app": {
     "windows": [
       {
-        "title": "Custom Tag Preview v0.86 · 2026-05-18 22:09",
+        "title": "Custom Tag Preview v0.86 · 2026-05-19 17:23",
         "width": 800,
         "height": 600,
         "resizable": true,

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted } from 'vue'
 import { api, type Item, type Tag } from './api'
+import { useToast } from './composables/useToast'
 import { listen, type UnlistenFn } from '@tauri-apps/api/event'
 import { useItemTypes } from './composables/useItemTypes'
 import ActivityBar from './components/ActivityBar.vue'
@@ -24,6 +25,7 @@ const allTags = ref<Tag[]>([])
 const workspaceGalleryRef = ref<InstanceType<typeof ItemGallery> | null>(null)
 const tagGalleryRef = ref<InstanceType<typeof ItemGallery> | null>(null)
 const lastMainView = ref<'workspace' | 'tags'>('workspace')
+const { show: showToast } = useToast()
 
 const handleActivitySelect = (id: string) => {
   activePanel.value = activePanel.value === id ? null : id
@@ -61,7 +63,10 @@ const handleFileItemUpdated = async () => {
   if (selectedFileItem.value) {
     try {
       selectedFileItem.value = await api.getItem(selectedFileItem.value.id)
-    } catch { /* ignore */ }
+    } catch (e) {
+      console.error('handleFileItemUpdated: failed to reload item', e)
+      showToast('無法重新載入檔案資訊', 'error')
+    }
   }
   workspaceGalleryRef.value?.refresh()
   tagGalleryRef.value?.refresh()

--- a/src/api.ts
+++ b/src/api.ts
@@ -119,7 +119,7 @@ export const api = {
     // ── Items (primary API) ───────────────────────────────────────────────────
     async getItems(
         page = 0,
-        size = 9999,
+        size = 200,
         tagIds?: number[],
         sortBy?: string,
         sortDir?: string,

--- a/src/composables/useGalleryData.ts
+++ b/src/composables/useGalleryData.ts
@@ -80,7 +80,7 @@ export function useGalleryData(
       const sPath = sourcePath();
       const tagIds = selectedTagIds();
       const sTagIds = tagIds?.length ? tagIds : undefined;
-      const pageSize = sTagIds ? TAG_PAGE_SIZE : 9999;
+      const pageSize = TAG_PAGE_SIZE;
       
       const res = await api.getItems(page, pageSize, sTagIds, 'importAt', 'desc', sTagIds ? undefined : (sPath ?? undefined));
       itemsData.value = res.content;


### PR DESCRIPTION
## 修復內容

### #54 預設 page size 9999 造成大收藏效能隱患
- 將預設 page size 從 9999 改為 200
- 3 個顯式傳參位置（useExternalChanges.ts:108, SourcePanel.vue:261,277）不受影響，無需修改

### #55 API 錯誤處理過於安靜（bare catch）
- 將 bare catch 改為 showToast 顯示錯誤通知

Closes #54
Fixes #55