### PR TITLE
fix: 外部更動「全部修復」改逐項處理 + Rust 容錯

### DIFF
--- a/src-tauri/src/scanner.rs
+++ b/src-tauri/src/scanner.rs
@@ -211,6 +211,12 @@ pub async fn incremental_scan_directory(
 
     for entry in &all_entries {
         let file_path = entry.path().to_string_lossy().to_string();
+
+        // 跳過根目錄本身（避免把工作目錄當成 folder 匯入）
+        if entry.path() == scan_root {
+            continue;
+        }
+
         let is_dir = entry.file_type().is_dir();
 
         // 對檔案：副檔名不在白名單就不自動匯入（但保留在 found_paths 中以免被誤刪）
@@ -224,7 +230,10 @@ pub async fn incremental_scan_directory(
             }
         }
 
-        let metadata = fs::metadata(entry.path())?;
+        let metadata = match fs::metadata(entry.path()) {
+            Ok(m) => m,
+            Err(_) => continue,  // 檔案無法讀取（鎖定/損毀/權限）→ 跳過，不中斷整個掃描
+        };
         let file_size = if is_dir { None } else { Some(metadata.len() as i64) };
         let mtime_unix = metadata.modified()
             .ok()

--- a/src/composables/useExternalChanges.ts
+++ b/src/composables/useExternalChanges.ts
@@ -121,11 +121,37 @@ export function useExternalChanges(sourcePath: () => string | null) {
     const path = sourcePath();
     if (!path) return;
     isFixing.value = true;
+
+    let added = 0, removed = 0, updated = 0, errors = 0;
+    const snapshot = [...changes.value];
+
     try {
-      const result = await api.incrementalScan(path);
-      lastFixResult.value = result;
+      for (const change of snapshot) {
+        try {
+          if (change.kind === 'untracked') {
+            await api.quickImportItem(change.path);
+            added++;
+          } else if (change.kind === 'missing') {
+            await api.untrackItem(change.path, { allowMissing: true });
+            removed++;
+          } else if (change.kind === 'modified') {
+            // 用 incrementalScan 同步所在資料夾（只更新已追蹤項目，不碰白名單限制）
+            const dir = parentDir(change.path);
+            if (dir) {
+              const result = await api.incrementalScan(dir);
+              if (result.updated > 0) updated++;
+            }
+          }
+        } catch (e) {
+          errors++;
+          console.error(`[useExternalChanges] fixAll item failed: ${change.path}`, e);
+        }
+      }
+
+      lastFixResult.value = { added, updated, removed };
       dismissedKeys.value.clear();
-      show(`已修復：新增 ${result.added}、更新 ${result.updated}、移除 ${result.removed}`, 'success');
+      const errMsg = errors > 0 ? `（${errors} 項失敗）` : '';
+      show(`已修復：新增 ${added}、更新 ${updated}、移除 ${removed}${errMsg}`, errors > added + removed ? 'error' : 'success');
       await refresh();
     } catch (e) {
       console.error('[useExternalChanges] fixAll failed', e);


### PR DESCRIPTION
## 根因（小狗 Gemini 3.5 Flash 分析）

`incrementalScan` 後端有副檔名白名單過濾，只處理 `type_extensions` 表中註冊的副檔名。但前端 `computeExternalChanges` 透過 `listDirFiles` 列出**所有**直屬子項。前端偵測到問題 → 後端跳過 → 回 (0,0,0) → 使用者感覺「沒反應」。

## 修復

### 主修（前端）— useExternalChanges.ts
`fixAll` 不再依賴 `incrementalScan`，改為遍歷 changes 陣列逐項處理：
- **untracked** → `quickImportItem`（無白名單檢查）
- **missing** → `untrackItem({ allowMissing: true })`
- **modified** → `incrementalScan(parentDir)`

### 副修（Rust）— scanner.rs
- `fs::metadata` 從 `?` 改為 `match + continue`，檔案鎖定/損毀時不中斷整個掃描
- 跳過根目錄（避免把工作目錄當成 folder 匯入）

Closes #?? （請手動關聯正確的 issue 編號）