### PR TITLE
feat: decouple folder tag rules from types

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,6 +1,7 @@
 mod debug;
 mod duplicates;
 mod filesystem;
+mod folder_rule_presets;
 mod helpers;
 mod item_lifecycle;
 mod item_types;
@@ -13,6 +14,7 @@ mod tags;
 pub use debug::*;
 pub use duplicates::*;
 pub use filesystem::*;
+pub use folder_rule_presets::*;
 pub use item_lifecycle::*;
 pub use item_types::*;
 pub use items::*;

--- a/src-tauri/src/commands/folder_rule_presets.rs
+++ b/src-tauri/src/commands/folder_rule_presets.rs
@@ -1,0 +1,166 @@
+use crate::models::{FolderRulePreset, FolderRulePresetInput};
+use sqlx::{Row, SqlitePool};
+use tauri::State;
+
+fn serialize_extensions(extensions: &[String]) -> String {
+    extensions
+        .iter()
+        .map(|ext| ext.trim().to_lowercase())
+        .filter(|ext| !ext.is_empty())
+        .map(|ext| {
+            if ext.starts_with('.') {
+                ext
+            } else {
+                format!(".{ext}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn parse_extensions(value: String) -> Vec<String> {
+    value
+        .split(',')
+        .map(|ext| ext.trim().to_string())
+        .filter(|ext| !ext.is_empty())
+        .collect()
+}
+
+fn preset_from_row(row: &sqlx::sqlite::SqliteRow) -> FolderRulePreset {
+    FolderRulePreset {
+        folder_item_id: row.get("folder_item_id"),
+        preset_type_id: row.get("preset_type_id"),
+        preset_name: row.get("preset_name"),
+        preset_display_name: row.get("preset_display_name"),
+        preset_icon: row.get("preset_icon"),
+        apply_to_subfolders: row.get::<i64, _>("apply_to_subfolders") != 0,
+        apply_to_files: row.get::<i64, _>("apply_to_files") != 0,
+        file_extensions: parse_extensions(row.get("file_extensions")),
+    }
+}
+
+async fn ensure_folder_item(pool: &SqlitePool, folder_item_id: i64) -> Result<(), String> {
+    let row = sqlx::query("SELECT item_type FROM items WHERE id = ?")
+        .bind(folder_item_id)
+        .fetch_optional(pool)
+        .await
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| "找不到指定資料夾".to_string())?;
+
+    let item_type: String = row.get("item_type");
+    if item_type != "folder" {
+        return Err("只有資料夾可以設定預設標籤規則集".to_string());
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn get_folder_rule_presets(
+    pool: State<'_, SqlitePool>,
+) -> Result<Vec<FolderRulePreset>, String> {
+    let rows = sqlx::query(
+        "SELECT frp.folder_item_id,
+                frp.preset_type_id,
+                it.name AS preset_name,
+                it.display_name AS preset_display_name,
+                it.icon AS preset_icon,
+                frp.apply_to_subfolders,
+                frp.apply_to_files,
+                frp.file_extensions
+         FROM folder_rule_presets frp
+         JOIN item_types it ON it.id = frp.preset_type_id
+         JOIN items item ON item.id = frp.folder_item_id
+         WHERE item.item_type = 'folder'
+         ORDER BY frp.folder_item_id ASC",
+    )
+    .fetch_all(&*pool)
+    .await
+    .map_err(|e| e.to_string())?;
+
+    Ok(rows.iter().map(preset_from_row).collect())
+}
+
+#[tauri::command]
+pub async fn get_folder_rule_preset(
+    folder_item_id: i64,
+    pool: State<'_, SqlitePool>,
+) -> Result<Option<FolderRulePreset>, String> {
+    let row = sqlx::query(
+        "SELECT frp.folder_item_id,
+                frp.preset_type_id,
+                it.name AS preset_name,
+                it.display_name AS preset_display_name,
+                it.icon AS preset_icon,
+                frp.apply_to_subfolders,
+                frp.apply_to_files,
+                frp.file_extensions
+         FROM folder_rule_presets frp
+         JOIN item_types it ON it.id = frp.preset_type_id
+         WHERE frp.folder_item_id = ?",
+    )
+    .bind(folder_item_id)
+    .fetch_optional(&*pool)
+    .await
+    .map_err(|e| e.to_string())?;
+
+    Ok(row.as_ref().map(preset_from_row))
+}
+
+#[tauri::command]
+pub async fn set_folder_rule_preset(
+    input: FolderRulePresetInput,
+    pool: State<'_, SqlitePool>,
+) -> Result<FolderRulePreset, String> {
+    ensure_folder_item(&pool, input.folder_item_id).await?;
+
+    let preset_exists: Option<i64> = sqlx::query_scalar("SELECT id FROM item_types WHERE id = ?")
+        .bind(input.preset_type_id)
+        .fetch_optional(&*pool)
+        .await
+        .map_err(|e| e.to_string())?;
+    if preset_exists.is_none() {
+        return Err("找不到指定標籤規則集".to_string());
+    }
+
+    sqlx::query(
+        "INSERT INTO folder_rule_presets (
+            folder_item_id,
+            preset_type_id,
+            apply_to_subfolders,
+            apply_to_files,
+            file_extensions,
+            updated_at
+         ) VALUES (?, ?, ?, ?, ?, datetime('now'))
+         ON CONFLICT(folder_item_id) DO UPDATE SET
+            preset_type_id = excluded.preset_type_id,
+            apply_to_subfolders = excluded.apply_to_subfolders,
+            apply_to_files = excluded.apply_to_files,
+            file_extensions = excluded.file_extensions,
+            updated_at = datetime('now')",
+    )
+    .bind(input.folder_item_id)
+    .bind(input.preset_type_id)
+    .bind(if input.apply_to_subfolders { 1 } else { 0 })
+    .bind(if input.apply_to_files { 1 } else { 0 })
+    .bind(serialize_extensions(&input.file_extensions))
+    .execute(&*pool)
+    .await
+    .map_err(|e| e.to_string())?;
+
+    get_folder_rule_preset(input.folder_item_id, pool)
+        .await?
+        .ok_or_else(|| "儲存標籤規則集失敗".to_string())
+}
+
+#[tauri::command]
+pub async fn clear_folder_rule_preset(
+    folder_item_id: i64,
+    pool: State<'_, SqlitePool>,
+) -> Result<(), String> {
+    sqlx::query("DELETE FROM folder_rule_presets WHERE folder_item_id = ?")
+        .bind(folder_item_id)
+        .execute(&*pool)
+        .await
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}

--- a/src-tauri/src/commands/item_types.rs
+++ b/src-tauri/src/commands/item_types.rs
@@ -215,6 +215,12 @@ pub async fn delete_item_type(id: i64, pool: State<'_, SqlitePool>) -> Result<()
 
     let type_name: String = row.get("name");
 
+    sqlx::query("DELETE FROM folder_rule_presets WHERE preset_type_id = ?")
+        .bind(id)
+        .execute(&*pool)
+        .await
+        .map_err(|e| e.to_string())?;
+
     db::reset_items_category_to_default(&*pool, &type_name)
         .await
         .map_err(|e| e.to_string())?;

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -162,6 +162,18 @@ pub async fn init_db(app_data_dir: &Path) -> Result<SqlitePool> {
     ).execute(&pool).await?;
 
     sqlx::query(
+        "CREATE TABLE IF NOT EXISTS folder_rule_presets (
+            folder_item_id      INTEGER PRIMARY KEY REFERENCES items(id) ON DELETE CASCADE,
+            preset_type_id      INTEGER NOT NULL REFERENCES item_types(id) ON DELETE CASCADE,
+            apply_to_subfolders INTEGER NOT NULL DEFAULT 0,
+            apply_to_files      INTEGER NOT NULL DEFAULT 0,
+            file_extensions     TEXT NOT NULL DEFAULT '',
+            created_at          TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at          TEXT NOT NULL DEFAULT (datetime('now'))
+        );"
+    ).execute(&pool).await?;
+
+    sqlx::query(
         "INSERT OR IGNORE INTO item_types (name, icon, display_name, is_builtin)
          VALUES ('default','📁','一般資料夾',1), ('comic','📚','漫畫',1)"
     ).execute(&pool).await?;
@@ -639,6 +651,26 @@ mod tests {
         assert!(dir.path().join("comic.db").exists());
         assert!(item_type_count >= 2);
         assert_eq!(zip_extension_count, 1);
+    }
+
+    #[tokio::test]
+    async fn init_db_creates_folder_rule_preset_bindings_table() {
+        let dir = tempdir().unwrap();
+        let pool = init_db(dir.path()).await.unwrap();
+
+        let table_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'folder_rule_presets'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let column_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM pragma_table_info('folder_rule_presets') WHERE name IN ('folder_item_id', 'preset_type_id', 'apply_to_subfolders', 'apply_to_files', 'file_extensions')")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+        assert_eq!(table_count, 1);
+        assert_eq!(column_count, 5);
     }
 
     #[tokio::test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -8,9 +8,9 @@ mod models;
 mod scanner;
 mod zip_utils;
 
+use serde_json::json;
 use tauri::Manager;
 use tauri_plugin_log::{Target, TargetKind};
-use serde_json::json;
 
 fn main() {
     tauri::Builder::default()
@@ -138,6 +138,10 @@ fn main() {
             commands::preview_tag_scan,
             commands::apply_tag_scan,
             commands::apply_rules_to_item,
+            commands::get_folder_rule_presets,
+            commands::get_folder_rule_preset,
+            commands::set_folder_rule_preset,
+            commands::clear_folder_rule_preset,
             // Sources
             commands::get_sources,
             commands::add_source,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -6,10 +6,10 @@ use serde::{Deserialize, Serialize};
 pub struct Item {
     pub id: i64,
     pub path: String,
-    pub item_type: String,           // 'file' | 'folder'
+    pub item_type: String, // 'file' | 'folder'
     pub name: String,
     pub file_size: Option<i64>,
-    pub file_modified_at: Option<i64>,   // Unix timestamp (seconds)
+    pub file_modified_at: Option<i64>, // Unix timestamp (seconds)
     pub cover_cache_path: Option<String>,
     pub fingerprint: Option<String>,
     pub note: Option<String>,
@@ -63,7 +63,7 @@ pub struct Page<T> {
 pub struct TagRule {
     pub id: i64,
     pub name: String,
-    pub match_type: String,  // 'prefix' | 'suffix' | 'contains' | 'regex'
+    pub match_type: String, // 'prefix' | 'suffix' | 'contains' | 'regex'
     pub pattern: String,
     pub tag_name: String,
 }
@@ -101,6 +101,29 @@ pub struct ItemTypeInput {
     pub example: String,
     pub extensions: Vec<String>,
     pub tag_rules: Vec<TagRuleInput>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct FolderRulePreset {
+    pub folder_item_id: i64,
+    pub preset_type_id: i64,
+    pub preset_name: String,
+    pub preset_display_name: String,
+    pub preset_icon: String,
+    pub apply_to_subfolders: bool,
+    pub apply_to_files: bool,
+    pub file_extensions: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct FolderRulePresetInput {
+    pub folder_item_id: i64,
+    pub preset_type_id: i64,
+    pub apply_to_subfolders: bool,
+    pub apply_to_files: bool,
+    pub file_extensions: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Clone)]

--- a/src/api.ts
+++ b/src/api.ts
@@ -136,6 +136,25 @@ export interface ItemTypeInput {
     tagRules: TagRuleInput[];
 }
 
+export interface FolderRulePreset {
+    folderItemId: number;
+    presetTypeId: number;
+    presetName: string;
+    presetDisplayName: string;
+    presetIcon: string;
+    applyToSubfolders: boolean;
+    applyToFiles: boolean;
+    fileExtensions: string[];
+}
+
+export interface FolderRulePresetInput {
+    folderItemId: number;
+    presetTypeId: number;
+    applyToSubfolders: boolean;
+    applyToFiles: boolean;
+    fileExtensions: string[];
+}
+
 export const api = {
     // ── Items (primary API) ───────────────────────────────────────────────────
     async getItems(
@@ -337,7 +356,24 @@ export const api = {
         return await invoke('apply_rules_to_item', { itemId, rules });
     },
 
-    // ── Duplicate detection ───────────────────────────────────────────────────
+    // ── Folder default rule presets ───────────────────────────────────────────
+    async getFolderRulePresets(): Promise<FolderRulePreset[]> {
+        return await invoke<FolderRulePreset[]>('get_folder_rule_presets');
+    },
+
+    async getFolderRulePreset(folderItemId: number): Promise<FolderRulePreset | null> {
+        return await invoke<FolderRulePreset | null>('get_folder_rule_preset', { folderItemId });
+    },
+
+    async setFolderRulePreset(input: FolderRulePresetInput): Promise<FolderRulePreset> {
+        return await invoke<FolderRulePreset>('set_folder_rule_preset', { input });
+    },
+
+    async clearFolderRulePreset(folderItemId: number): Promise<void> {
+        await invoke('clear_folder_rule_preset', { folderItemId });
+    },
+
+    // ── Duplicate detection
     async getDuplicateGroups(): Promise<DuplicateGroup[]> {
         return await invoke('get_duplicate_groups');
     },

--- a/src/components/CategoryEditor.vue
+++ b/src/components/CategoryEditor.vue
@@ -35,7 +35,7 @@ const localExtInput = computed({
 
 <template>
     <div class="type-form">
-        <h3 class="form-title">{{ isNew ? '新增類型' : '編輯類型' }}</h3>
+        <h3 class="form-title">{{ isNew ? '新增規則集' : '編輯規則集' }}</h3>
 
         <label class="field-label">識別名稱（英數字+底線）</label>
         <input
@@ -45,7 +45,7 @@ const localExtInput = computed({
             placeholder="例：novel"
         />
 
-        <label class="field-label">顯示名稱</label>
+        <label class="field-label">規則集名稱</label>
         <input
             v-model="form.displayName"
             class="field-input"
@@ -95,7 +95,7 @@ const localExtInput = computed({
         <p class="field-hint">不含點號，例：zip、epub、cbz</p>
 
         <label class="field-label field-label--spaced">自動標記規則</label>
-        <p class="field-hint">指定此類別後，自動對資料夾內的檔案套用以下規則打標籤</p>
+        <p class="field-hint">選擇此規則集時，依下列規則替項目加標籤；資料夾本身仍只是資料夾。</p>
         <div class="rule-list">
             <div v-for="(rule, i) in form.tagRules" :key="i" class="rule-row">
                 <select v-model="rule.matchType" class="rule-select">

--- a/src/components/CategoryEditor.vue
+++ b/src/components/CategoryEditor.vue
@@ -2,19 +2,27 @@
 import { computed } from 'vue';
 import RuleTester from './RuleTester.vue';
 
+interface RuleFormItem {
+    matchType: string;
+    pattern: string;
+    tagName: string;
+}
+
+interface CategoryForm {
+    name: string;
+    icon: string;
+    displayName: string;
+    color: string;
+    example: string;
+    extensions: string[];
+    tagRules: RuleFormItem[];
+}
+
 const props = defineProps<{
     isNew: boolean;
     saving: boolean;
     extInput: string;
-    form: {
-        name: string;
-        icon: string;
-        displayName: string;
-        color: string;
-        example: string;
-        extensions: string[];
-        tagRules: Array<{ matchType: string; pattern: string; tagName: string }>;
-    };
+    form: CategoryForm;
 }>();
 
 const emit = defineEmits<{
@@ -26,293 +34,650 @@ const emit = defineEmits<{
     (e: 'save'): void;
 }>();
 
-// computed getters/setters for v-model to props mutation warning fix
 const localExtInput = computed({
     get: () => props.extInput,
     set: (val) => emit('update:extInput', val)
 });
+
+const matchTypeOptions = [
+    { value: 'prefix', label: '前綴', hint: '從檔名開頭比對' },
+    { value: 'suffix', label: '後綴', hint: '從檔名結尾比對' },
+    { value: 'contains', label: '包含', hint: '檔名包含文字' },
+    { value: 'regex', label: '正規', hint: '正規表達式命中' },
+    { value: 'regex_capture', label: '正規擷取', hint: '用括號擷取標籤' },
+];
+
+const editorTitle = computed(() => props.isNew ? '建立標籤規則集' : '編輯標籤規則集');
+const ruleCount = computed(() => props.form.tagRules.length);
+const extensionCount = computed(() => props.form.extensions.length);
+const scopeSummary = computed(() => extensionCount.value === 0 ? '所有副檔名' : `${extensionCount.value} 個副檔名`);
 </script>
 
 <template>
     <div class="type-form">
-        <h3 class="form-title">{{ isNew ? '新增規則集' : '編輯規則集' }}</h3>
-
-        <label class="field-label">識別名稱（英數字+底線）</label>
-        <input
-            v-model="form.name"
-            class="field-input"
-            :disabled="!isNew"
-            placeholder="例：novel"
-        />
-
-        <label class="field-label">規則集名稱</label>
-        <input
-            v-model="form.displayName"
-            class="field-input"
-            placeholder="例：小說"
-        />
-
-        <label class="field-label">圖示（Emoji）</label>
-        <input
-            v-model="form.icon"
-            class="field-input icon-input"
-            placeholder="📁"
-            maxlength="4"
-        />
-
-        <label class="field-label">標記顏色（選填）</label>
-        <div class="color-row">
-            <input type="color" v-model="form.color" class="color-picker" />
-            <input v-model="form.color" class="field-input color-text" placeholder="#ffffff（留空表示無顏色）" />
-            <button v-if="form.color" class="clear-color-btn" @click="form.color = ''" title="清除顏色">✕</button>
-        </div>
-
-        <label class="field-label">範例（純記錄用）</label>
-        <textarea
-            v-model="form.example"
-            class="field-input field-textarea"
-            rows="2"
-            placeholder="例：[進擊的巨人(第一季、完結)] 第01話.mkv"
-        ></textarea>
-
-        <label class="field-label">允許的副檔名</label>
-        <div class="ext-tags">
-            <span
-                v-for="ext in form.extensions"
-                :key="ext"
-                class="ext-tag"
-            >
-                {{ ext }}
-                <button class="ext-del" @click="emit('removeExt', ext)">×</button>
-            </span>
-            <input
-                v-model="localExtInput"
-                class="ext-input"
-                placeholder="輸入副檔名後按 Enter 新增"
-                @keydown.enter.prevent="emit('addExt')"
-            />
-        </div>
-        <p class="field-hint">不含點號，例：zip、epub、cbz</p>
-
-        <label class="field-label field-label--spaced">自動標記規則</label>
-        <p class="field-hint">選擇此規則集時，依下列規則替項目加標籤；資料夾本身仍只是資料夾。</p>
-        <div class="rule-list">
-            <div v-for="(rule, i) in form.tagRules" :key="i" class="rule-row">
-                <select v-model="rule.matchType" class="rule-select">
-                    <option value="prefix">前綴</option>
-                    <option value="suffix">後綴</option>
-                    <option value="contains">包含</option>
-                    <option value="regex">正規表達式</option>
-                    <option value="regex_capture">正規擷取</option>
-                </select>
-                <input v-model="rule.pattern" class="rule-input" placeholder="模式" />
-                <input
-                    v-model="rule.tagName"
-                    class="rule-input"
-                    placeholder="標籤名稱"
-                    :disabled="rule.matchType === 'regex_capture'"
-                    :title="rule.matchType === 'regex_capture' ? '正規擷取模式下，標籤名稱由括號擷取組決定' : ''"
-                />
-                <button class="rule-del" @click="emit('removeRule', i)" title="刪除">✕</button>
+        <header class="form-header">
+            <div class="form-title-block">
+                <span class="form-eyebrow">Rule set editor</span>
+                <h3>{{ editorTitle }}</h3>
+                <p>定義檔案適用範圍與自動套標籤規則。這是自動化模板，不會改變資料夾本身。</p>
             </div>
-            <button class="add-rule-btn" @click="emit('addRule')">＋ 新增規則</button>
-        </div>
+            <div class="form-stats" aria-label="規則集摘要">
+                <span><strong>{{ scopeSummary }}</strong></span>
+                <span><strong>{{ ruleCount }}</strong> 規則</span>
+            </div>
+        </header>
 
-        <label class="field-label field-label--spaced">即時測試</label>
-        <RuleTester
-            :rules="form.tagRules"
-            :placeholder="form.example || '輸入測試檔名…'"
-        />
+        <section class="editor-card">
+            <div class="section-heading">
+                <span class="section-index">01</span>
+                <div>
+                    <h4>基本識別</h4>
+                    <p>給規則集一個可辨識的名稱、圖示與顏色。</p>
+                </div>
+            </div>
 
-        <div class="form-actions">
-            <button class="save-btn" :disabled="saving" @click="emit('save')">
-                {{ saving ? '儲存中...' : '儲存' }}
+            <div class="field-grid">
+                <label class="field-block">
+                    <span class="field-label">識別名稱</span>
+                    <input
+                        v-model="form.name"
+                        class="field-input mono-input"
+                        :disabled="!isNew"
+                        placeholder="例：novel"
+                    />
+                    <small>僅限小寫英數字與底線，建立後不可修改。</small>
+                </label>
+
+                <label class="field-block">
+                    <span class="field-label">顯示名稱</span>
+                    <input
+                        v-model="form.displayName"
+                        class="field-input"
+                        placeholder="例：小說"
+                    />
+                    <small>顯示在設定、右鍵選單與資料夾自動化區塊。</small>
+                </label>
+
+                <label class="field-block compact-field">
+                    <span class="field-label">圖示</span>
+                    <input
+                        v-model="form.icon"
+                        class="field-input icon-input"
+                        placeholder="📁"
+                        maxlength="4"
+                    />
+                </label>
+
+                <div class="field-block">
+                    <span class="field-label">標記顏色</span>
+                    <div class="color-row">
+                        <input type="color" v-model="form.color" class="color-picker" />
+                        <input v-model="form.color" class="field-input color-text" placeholder="#ffffff（留空表示無顏色）" />
+                        <button v-if="form.color" type="button" class="icon-btn danger" @click="form.color = ''" title="清除顏色">✕</button>
+                    </div>
+                </div>
+            </div>
+
+            <label class="field-block full-field">
+                <span class="field-label">範例檔名</span>
+                <textarea
+                    v-model="form.example"
+                    class="field-input field-textarea"
+                    rows="2"
+                    placeholder="例：[進擊的巨人(第一季、完結)] 第01話.mkv"
+                ></textarea>
+                <small>純記錄用，也會成為即時測試的預設提示。</small>
+            </label>
+        </section>
+
+        <section class="editor-card">
+            <div class="section-heading">
+                <span class="section-index">02</span>
+                <div>
+                    <h4>適用範圍</h4>
+                    <p>限制哪些副檔名會使用這套規則；留空代表不限制。</p>
+                </div>
+            </div>
+
+            <div class="ext-tags">
+                <span
+                    v-for="ext in form.extensions"
+                    :key="ext"
+                    class="ext-tag"
+                >
+                    {{ ext }}
+                    <button type="button" class="ext-del" @click="emit('removeExt', ext)" aria-label="移除副檔名">×</button>
+                </span>
+                <input
+                    v-model="localExtInput"
+                    class="ext-input"
+                    placeholder="輸入副檔名後按 Enter 新增，例如 zip、epub、cbz"
+                    @keydown.enter.prevent="emit('addExt')"
+                />
+            </div>
+            <p class="field-hint">不含點號；資料夾預設規則可另外限制是否套用到子資料夾與檔案。</p>
+        </section>
+
+        <section class="editor-card">
+            <div class="section-heading with-action">
+                <span class="section-index">03</span>
+                <div>
+                    <h4>自動標記規則</h4>
+                    <p>依檔名命中條件後自動加上標籤；正規擷取模式會使用括號擷取結果當標籤。</p>
+                </div>
+                <button type="button" class="secondary-btn" @click="emit('addRule')">＋ 新增規則</button>
+            </div>
+
+            <div v-if="form.tagRules.length === 0" class="empty-rules">
+                尚未建立規則。可以先新增一條「包含」或「正規擷取」規則，再用下方即時測試確認命中結果。
+            </div>
+
+            <div v-else class="rule-list">
+                <div v-for="(rule, index) in form.tagRules" :key="index" class="rule-row">
+                    <span class="rule-number">{{ index + 1 }}</span>
+                    <label class="rule-field rule-field--type">
+                        <span>比對方式</span>
+                        <select v-model="rule.matchType" class="rule-select">
+                            <option
+                                v-for="option in matchTypeOptions"
+                                :key="option.value"
+                                :value="option.value"
+                            >{{ option.label }}</option>
+                        </select>
+                    </label>
+                    <label class="rule-field">
+                        <span>模式</span>
+                        <input v-model="rule.pattern" class="rule-input mono-input" placeholder="例如 [作者] 或 ^\[(.+?)\]" />
+                    </label>
+                    <label class="rule-field">
+                        <span>標籤名稱</span>
+                        <input
+                            v-model="rule.tagName"
+                            class="rule-input"
+                            placeholder="例：作者 / 待整理"
+                            :disabled="rule.matchType === 'regex_capture'"
+                            :title="rule.matchType === 'regex_capture' ? '正規擷取模式下，標籤名稱由括號擷取組決定' : ''"
+                        />
+                    </label>
+                    <button type="button" class="icon-btn danger" @click="emit('removeRule', index)" title="刪除規則">✕</button>
+                </div>
+            </div>
+        </section>
+
+        <section class="editor-card">
+            <div class="section-heading">
+                <span class="section-index">04</span>
+                <div>
+                    <h4>即時測試</h4>
+                    <p>輸入檔名後會直接顯示哪些規則命中與產生的標籤。</p>
+                </div>
+            </div>
+            <RuleTester
+                :rules="form.tagRules"
+                :placeholder="form.example || '輸入測試檔名…'"
+            />
+        </section>
+
+        <footer class="form-actions">
+            <button type="button" class="save-btn" :disabled="saving" @click="emit('save')">
+                {{ saving ? '儲存中...' : '儲存規則集' }}
             </button>
-        </div>
+        </footer>
     </div>
 </template>
 
 <style scoped>
 .type-form {
     flex: 1;
-    padding: 20px 24px;
+    min-width: 0;
+    min-height: 0;
     overflow-y: auto;
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: 14px;
+    padding: 20px;
 }
-.form-title {
-    font-size: 0.95rem;
-    font-weight: 600;
-    color: var(--text-primary);
-    margin: 0 0 12px;
-}
-.field-label {
-    font-size: 0.8rem;
-    color: var(--text-secondary);
-    margin-top: 10px;
-}
-.field-label--spaced { margin-top: 16px; }
-.field-input {
-    background: var(--bg-overlay-soft);
+
+.form-header,
+.editor-card,
+.form-actions {
     border: 1px solid var(--border-default);
-    border-radius: 6px;
-    color: var(--text-primary);
-    font-size: 0.9rem;
-    padding: 6px 10px;
-    outline: none;
-    width: 100%;
-    box-sizing: border-box;
-    margin-top: 4px;
+    border-radius: var(--radius-lg);
+    background: color-mix(in srgb, var(--bg-elevated) 78%, transparent);
+    box-shadow: var(--shadow-sm);
 }
-.field-input:disabled { opacity: 0.4; cursor: not-allowed; }
-.field-input:focus { border-color: var(--accent); }
-.icon-input { width: 80px; font-size: 1.2rem; text-align: center; }
+
+.form-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 18px;
+}
+
+.form-title-block,
+.section-heading > div,
+.field-block,
+.rule-field {
+    min-width: 0;
+}
+
+.form-eyebrow {
+    font-family: var(--font-mono);
+    font-size: 0.64rem;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: var(--text-tertiary);
+}
+
+.form-title-block h3,
+.section-heading h4 {
+    margin: 6px 0;
+    color: var(--text-primary);
+    letter-spacing: -0.02em;
+}
+
+.form-title-block h3 {
+    font-size: 1.15rem;
+}
+
+.form-title-block p,
+.section-heading p,
+.field-hint,
+.field-block small {
+    margin: 0;
+    color: var(--text-secondary);
+    line-height: 1.55;
+    font-size: 0.78rem;
+}
+
+.form-stats {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 6px;
+    min-width: 0;
+    flex-shrink: 0;
+}
+
+.form-stats span {
+    display: inline-flex;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-pill);
+    padding: 5px 8px;
+    background: var(--bg-overlay-soft);
+    color: var(--text-secondary);
+    font-size: 0.72rem;
+}
+
+.form-stats strong {
+    color: var(--text-primary);
+}
+
+.editor-card {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    padding: 18px;
+    min-width: 0;
+}
+
+.section-heading {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    min-width: 0;
+}
+
+.section-heading.with-action {
+    align-items: center;
+}
+
+.section-heading.with-action > div {
+    flex: 1;
+}
+
+.section-index {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    border: 1px solid var(--accent-border);
+    background: var(--accent-bg-subtle);
+    color: var(--accent);
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    flex-shrink: 0;
+}
+
+.section-heading h4 {
+    font-size: 0.98rem;
+}
+
+.field-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 12px;
+}
+
+.field-block {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.full-field {
+    width: 100%;
+}
+
+.compact-field {
+    max-width: 120px;
+}
+
+.field-label,
+.rule-field span {
+    color: var(--text-secondary);
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+
+.field-input,
+.rule-input,
+.rule-select {
+    width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
+    background: var(--bg-input);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md);
+    color: var(--text-primary);
+    font-size: 0.88rem;
+    padding: 8px 10px;
+    outline: none;
+    font-family: inherit;
+    transition: border-color var(--transition-fast), background var(--transition-fast);
+}
+
+.field-input:disabled,
+.rule-input:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+}
+
+.mono-input {
+    font-family: var(--font-mono);
+}
+
+.icon-input {
+    text-align: center;
+    font-size: 1.15rem;
+}
+
 .field-textarea {
     resize: vertical;
-    min-height: 48px;
-    font-family: inherit;
-    line-height: 1.4;
+    min-height: 54px;
+    line-height: 1.45;
 }
+
+.color-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+}
+
+.color-picker {
+    width: 38px;
+    height: 36px;
+    flex-shrink: 0;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md);
+    padding: 2px;
+    background: transparent;
+    cursor: pointer;
+}
+
+.color-text {
+    flex: 1;
+}
+
 .ext-tags {
     display: flex;
     flex-wrap: wrap;
-    gap: 6px;
+    gap: 7px;
     align-items: center;
-    background: var(--bg-overlay-soft);
-    border: 1px solid var(--border-default);
-    border-radius: 6px;
-    padding: 6px 8px;
-    margin-top: 4px;
-    min-height: 36px;
     min-width: 0;
-    overflow: hidden;
+    min-height: 44px;
+    background: var(--bg-input);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md);
+    padding: 8px;
 }
+
 .ext-tag {
     display: inline-flex;
     align-items: center;
-    gap: 4px;
-    background: var(--bg-overlay-strong);
-    border-radius: 4px;
-    padding: 2px 6px;
-    font-size: 0.8rem;
-    color: var(--text-primary);
+    gap: 5px;
     max-width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
     flex-shrink: 0;
+    background: var(--accent-bg-subtle);
+    border: 1px solid var(--accent-border);
+    border-radius: var(--radius-pill);
+    padding: 3px 8px;
+    color: var(--accent);
+    font-size: 0.78rem;
 }
+
 .ext-del {
+    flex-shrink: 0;
     background: transparent;
     border: none;
-    color: var(--text-secondary);
+    color: currentColor;
     cursor: pointer;
-    font-size: 0.75rem;
     padding: 0;
     line-height: 1;
-    flex-shrink: 0;
 }
-.ext-del:hover { color: var(--color-danger); }
+
 .ext-input {
+    flex: 1 1 160px;
+    min-width: 0;
+    width: 0;
     background: transparent;
-    border: none;
+    border: 1px solid transparent;
+    border-radius: var(--radius-sm);
     outline: none;
     color: var(--text-primary);
     font-size: 0.85rem;
-    flex: 1 1 100px;
-    min-width: 0;
-    width: 0;
+    padding: 5px 6px;
 }
-.ext-input::placeholder { color: var(--text-secondary); }
-.field-hint {
-    font-size: 0.75rem;
-    color: var(--text-secondary);
-    margin: 2px 0 0;
+
+.ext-input::placeholder,
+.field-input::placeholder,
+.rule-input::placeholder {
+    color: var(--text-tertiary);
 }
+
 .rule-list {
     display: flex;
     flex-direction: column;
-    gap: 6px;
-    margin-top: 4px;
+    gap: 8px;
 }
+
 .rule-row {
     display: flex;
-    gap: 6px;
-    align-items: center;
+    align-items: flex-end;
+    gap: 8px;
+    min-width: 0;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    background: var(--bg-overlay-soft);
+    padding: 10px;
 }
+
+.rule-number {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 26px;
+    height: 34px;
+    flex-shrink: 0;
+    color: var(--text-tertiary);
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+}
+
+.rule-field {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    flex: 1 1 0;
+}
+
+.rule-field--type {
+    flex: 0.65 1 0;
+}
+
 .rule-select {
     -webkit-appearance: none;
     appearance: none;
-    background: var(--bg-input);
-    border: 1px solid var(--border-default);
-    border-radius: 6px;
-    color: var(--text-primary);
-    font-size: 0.82rem;
-    padding: 5px 6px;
-    outline: none;
-    flex-shrink: 0;
-    width: 90px;
     cursor: pointer;
 }
-.rule-select:focus { border-color: var(--accent); }
-.rule-input {
-    background: var(--bg-input);
-    border: 1px solid var(--border-default);
-    border-radius: 6px;
-    color: var(--text-primary);
-    font-size: 0.85rem;
-    padding: 5px 8px;
-    outline: none;
-    flex: 1;
-    min-width: 0;
-    font-family: inherit;
+
+.field-input:focus,
+.rule-input:focus,
+.rule-select:focus,
+.ext-input:focus {
+    border-color: var(--accent);
+    box-shadow: var(--ring-focus);
 }
-.rule-input:focus { border-color: var(--accent); }
-.rule-input:disabled { opacity: 0.3; cursor: not-allowed; }
-.rule-del {
-    background: transparent;
-    border: none;
-    color: var(--text-secondary);
-    font-size: 0.75rem;
-    cursor: pointer;
-    padding: 4px 6px;
-    border-radius: 4px;
-    flex-shrink: 0;
-    transition: color 0.15s;
-}
-.rule-del:hover { color: var(--color-danger); }
-.add-rule-btn {
-    background: transparent;
+
+.empty-rules {
     border: 1px dashed var(--border-default);
+    border-radius: var(--radius-md);
+    background: var(--bg-overlay-soft);
     color: var(--text-secondary);
-    border-radius: 6px;
-    padding: 5px 10px;
-    cursor: pointer;
+    padding: 14px;
+    line-height: 1.6;
     font-size: 0.82rem;
-    transition: color 0.15s, border-color 0.15s;
-    align-self: flex-start;
-    margin-top: 2px;
 }
-.add-rule-btn:hover { color: var(--text-primary); border-color: var(--accent); }
+
+.secondary-btn,
+.save-btn,
+.icon-btn {
+    cursor: pointer;
+    transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast), opacity var(--transition-fast);
+}
+
+.secondary-btn {
+    flex-shrink: 0;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md);
+    background: transparent;
+    color: var(--text-secondary);
+    padding: 8px 10px;
+    font-size: 0.82rem;
+}
+
+.secondary-btn:hover {
+    border-color: var(--accent-border);
+    background: var(--accent-bg-subtle);
+    color: var(--text-primary);
+}
+
+.icon-btn {
+    flex-shrink: 0;
+    width: 32px;
+    height: 34px;
+    border-radius: var(--radius-md);
+    border: 1px solid var(--border-default);
+    background: transparent;
+    color: var(--text-tertiary);
+}
+
+.icon-btn.danger:hover {
+    border-color: var(--color-danger);
+    background: var(--color-danger-bg-subtle);
+    color: var(--color-danger);
+}
+
 .form-actions {
-    margin-top: 16px;
+    display: flex;
+    justify-content: flex-end;
+    padding: 12px 14px;
+    flex-shrink: 0;
 }
+
 .save-btn {
+    border: 1px solid var(--accent-border);
+    border-radius: var(--radius-md);
     background: var(--accent);
-    border: none;
-    border-radius: 6px;
     color: var(--text-on-accent);
     font-size: 0.9rem;
-    padding: 8px 20px;
-    cursor: pointer;
-    transition: opacity 0.15s;
+    font-weight: 700;
+    padding: 9px 18px;
+    box-shadow: var(--shadow-accent-elevated);
 }
-.save-btn:disabled { opacity: 0.4; cursor: not-allowed; }
-.save-btn:hover:not(:disabled) { opacity: 0.85; }
-.color-row { display: flex; align-items: center; gap: 8px; margin-top: 4px; }
-.color-picker { width: 36px; height: 32px; border: 1px solid var(--border-default); border-radius: 6px; padding: 2px; background: transparent; cursor: pointer; flex-shrink: 0; }
-.color-text { flex: 1; }
-.clear-color-btn { background: transparent; border: 1px solid var(--border-default); border-radius: 4px; color: var(--text-secondary); font-size: 0.75rem; padding: 4px 6px; cursor: pointer; flex-shrink: 0; }
-.clear-color-btn:hover { color: var(--color-danger); }
+
+.save-btn:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+}
+
+.save-btn:hover:not(:disabled) {
+    background: var(--accent-hover);
+}
+
+@media (max-width: 760px) {
+    .type-form {
+        overflow: visible;
+    }
+
+    .form-header,
+    .section-heading.with-action {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .form-stats {
+        justify-content: flex-start;
+    }
+
+    .field-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .compact-field {
+        max-width: none;
+    }
+
+    .rule-row {
+        flex-wrap: wrap;
+        align-items: stretch;
+    }
+
+    .rule-number {
+        width: auto;
+        height: auto;
+        padding-top: 8px;
+    }
+
+    .rule-field,
+    .rule-field--type {
+        flex-basis: 100%;
+    }
+
+    .icon-btn {
+        width: 100%;
+    }
+
+    .secondary-btn,
+    .save-btn {
+        width: 100%;
+    }
+}
 </style>

--- a/src/components/CategoryList.vue
+++ b/src/components/CategoryList.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { ItemType } from '../api';
 
-defineProps<{
+const props = defineProps<{
     itemTypes: ItemType[];
     selectedId: number | null;
     isNew: boolean;
@@ -12,87 +12,288 @@ const emit = defineEmits<{
     (e: 'startNew'): void;
     (e: 'delete', type: ItemType): void;
 }>();
+
+const formatExtensionCount = (type: ItemType) => (
+    type.extensions.length === 0 ? '不限副檔名' : `${type.extensions.length} 副檔名`
+);
+
+const formatRuleCount = (type: ItemType) => `${type.tagRules.length} 規則`;
 </script>
 
 <template>
-    <div class="type-list">
-        <div
-            v-for="t in itemTypes"
-            :key="t.id"
-            class="type-item"
-            :class="{ active: selectedId === t.id && !isNew }"
-            @click="emit('select', t)"
-        >
-            <span class="type-icon">{{ t.icon }}</span>
-            <span class="type-name">{{ t.displayName }}</span>
-            <span v-if="t.isBuiltin" class="builtin-badge">內建</span>
-            <button
-                v-else
-                class="del-btn"
-                @click.stop="emit('delete', t)"
-                title="刪除"
-            >✕</button>
+    <aside class="rule-set-library">
+        <div class="library-header">
+            <span class="library-eyebrow">Rule sets</span>
+            <h3>規則集庫</h3>
+            <p>選擇一組規則來編輯，或新增自訂自動化規則集。</p>
         </div>
-        <button class="add-type-btn" @click="emit('startNew')">＋ 新增規則集</button>
-    </div>
+
+        <button
+            type="button"
+            class="add-type-btn"
+            :class="{ active: isNew }"
+            @click="emit('startNew')"
+        >
+            <span class="add-mark">＋</span>
+            <span class="add-type-content">
+                <strong>新增規則集</strong>
+                <small>建立新的套標籤模板</small>
+            </span>
+        </button>
+
+        <div class="type-list" role="list" aria-label="標籤規則集清單">
+            <div
+                v-for="type in props.itemTypes"
+                :key="type.id"
+                role="button"
+                tabindex="0"
+                class="type-item"
+                :class="{ active: selectedId === type.id && !isNew }"
+                @click="emit('select', type)"
+                @keydown.enter.prevent="emit('select', type)"
+                @keydown.space.prevent="emit('select', type)"
+            >
+                <span class="type-icon" :style="{ color: type.color ?? undefined }">{{ type.icon }}</span>
+                <span class="type-copy">
+                    <span class="type-name">{{ type.displayName }}</span>
+                    <span class="type-meta">
+                        <span>{{ formatExtensionCount(type) }}</span>
+                        <span>{{ formatRuleCount(type) }}</span>
+                    </span>
+                </span>
+                <span v-if="type.isBuiltin" class="builtin-badge">內建</span>
+                <button
+                    v-else
+                    type="button"
+                    class="del-btn"
+                    @click.stop="emit('delete', type)"
+                    title="刪除規則集"
+                    aria-label="刪除規則集"
+                >✕</button>
+            </div>
+        </div>
+    </aside>
 </template>
 
 <style scoped>
-.type-list {
-    width: 200px;
-    border-right: 1px solid var(--border-default);
-    overflow-y: auto;
-    padding: 8px 0;
-    flex-shrink: 0;
+.rule-set-library {
     display: flex;
     flex-direction: column;
+    gap: 12px;
+    min-width: 0;
+    min-height: 0;
+    padding: 18px;
+    overflow: hidden;
+    background: color-mix(in srgb, var(--bg-panel) 88%, transparent);
 }
+
+.library-header {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-width: 0;
+    flex-shrink: 0;
+}
+
+.library-eyebrow {
+    font-family: var(--font-mono);
+    font-size: 0.64rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--text-tertiary);
+}
+
+.library-header h3 {
+    margin: 0;
+    color: var(--text-primary);
+    font-size: 1rem;
+    letter-spacing: -0.01em;
+}
+
+.library-header p {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 0.78rem;
+    line-height: 1.5;
+}
+
+.add-type-btn,
+.type-item {
+    width: 100%;
+    min-width: 0;
+    border-radius: var(--radius-lg);
+    cursor: pointer;
+    transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
+}
+
+.add-type-btn {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px;
+    border: 1px dashed var(--border-default);
+    background: var(--accent-bg-subtle);
+    color: var(--text-primary);
+    text-align: left;
+    flex-shrink: 0;
+}
+
+.add-type-btn:hover,
+.add-type-btn.active {
+    border-color: var(--accent-border);
+    background: var(--accent-bg-strong);
+}
+
+.add-mark {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    background: var(--accent);
+    color: var(--text-on-accent);
+    flex-shrink: 0;
+    font-weight: 700;
+}
+
+.add-type-content {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+
+.add-type-btn strong {
+    font-size: 0.86rem;
+}
+
+.add-type-btn small {
+    color: var(--text-secondary);
+    font-size: 0.72rem;
+}
+
+.type-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-height: 0;
+    overflow-y: auto;
+    padding-right: 2px;
+}
+
 .type-item {
     display: flex;
     align-items: center;
-    gap: 8px;
-    padding: 8px 14px;
-    cursor: pointer;
+    gap: 10px;
+    padding: 10px;
+    border: 1px solid transparent;
+    background: transparent;
     color: var(--text-secondary);
-    font-size: 0.9rem;
-    transition: background 0.15s, color 0.15s;
+    text-align: left;
 }
-.type-item:hover { background: var(--bg-overlay-soft); color: var(--text-primary); }
-.type-item.active { background: var(--bg-overlay-strong); color: var(--text-primary); }
-.type-icon { font-size: 1rem; flex-shrink: 0; }
-.type-name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+.type-item:hover {
+    background: var(--bg-overlay-soft);
+    color: var(--text-primary);
+}
+
+.type-item.active {
+    background: var(--bg-overlay-strong);
+    border-color: var(--accent-border);
+    color: var(--text-primary);
+}
+
+.type-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: var(--radius-md);
+    background: var(--bg-overlay-soft);
+    border: 1px solid var(--border-subtle);
+    font-size: 1.1rem;
+    flex-shrink: 0;
+}
+
+.type-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    flex: 1;
+    min-width: 0;
+}
+
+.type-name {
+    color: var(--text-primary);
+    font-size: 0.86rem;
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.type-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+    min-width: 0;
+}
+
+.type-meta span,
 .builtin-badge {
-    font-size: 0.65rem;
-    color: var(--text-secondary);
-    border: 1px solid var(--border-default);
-    border-radius: 3px;
-    padding: 1px 4px;
+    display: inline-flex;
+    align-items: center;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-pill);
+    padding: 2px 6px;
+    background: var(--bg-overlay-soft);
+    color: var(--text-tertiary);
+    font-size: 0.66rem;
+    line-height: 1.2;
+    white-space: nowrap;
+}
+
+.builtin-badge {
+    color: var(--accent);
+    border-color: var(--accent-border);
+    background: var(--accent-bg-subtle);
     flex-shrink: 0;
 }
+
 .del-btn {
-    background: transparent;
-    border: none;
-    color: var(--text-secondary);
-    font-size: 0.75rem;
-    cursor: pointer;
-    padding: 2px 4px;
-    border-radius: 3px;
     flex-shrink: 0;
-    opacity: 0;
-    transition: opacity 0.15s;
-}
-.del-btn:hover { color: var(--color-danger); }
-.type-item:hover .del-btn { opacity: 1; }
-.add-type-btn {
-    margin: 8px 10px 4px;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
     background: transparent;
-    border: 1px dashed var(--border-default);
-    color: var(--text-secondary);
-    border-radius: 6px;
-    padding: 6px 10px;
+    border: 1px solid transparent;
+    color: var(--text-tertiary);
+    font-size: 0.72rem;
     cursor: pointer;
-    font-size: 0.85rem;
-    transition: color 0.15s, border-color 0.15s;
+    opacity: 0;
+    transition: opacity var(--transition-fast), color var(--transition-fast), background var(--transition-fast), border-color var(--transition-fast);
 }
-.add-type-btn:hover { color: var(--text-primary); border-color: var(--accent); }
+
+.del-btn:hover {
+    color: var(--color-danger);
+    background: var(--color-danger-bg-subtle);
+    border-color: var(--color-danger);
+}
+
+.type-item:hover .del-btn,
+.type-item:focus-within .del-btn {
+    opacity: 1;
+}
+
+@media (max-width: 820px) {
+    .rule-set-library {
+        overflow: visible;
+    }
+
+    .type-list {
+        max-height: 260px;
+    }
+}
 </style>

--- a/src/components/CategoryList.vue
+++ b/src/components/CategoryList.vue
@@ -33,7 +33,7 @@ const emit = defineEmits<{
                 title="刪除"
             >✕</button>
         </div>
-        <button class="add-type-btn" @click="emit('startNew')">＋ 新增類型</button>
+        <button class="add-type-btn" @click="emit('startNew')">＋ 新增規則集</button>
     </div>
 </template>
 

--- a/src/components/CategoryManageModal.vue
+++ b/src/components/CategoryManageModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { watch } from 'vue';
+import { computed, watch } from 'vue';
 import CategoryList from './CategoryList.vue';
 import CategoryEditor from './CategoryEditor.vue';
 import { useCategoryManage } from '../composables/useCategoryManage';
@@ -26,6 +26,10 @@ const {
     deleteType
 } = useCategoryManage();
 
+const totalRules = computed(() => itemTypes.value.reduce((sum, type) => sum + type.tagRules.length, 0));
+const customRuleSets = computed(() => itemTypes.value.filter(type => !type.isBuiltin).length);
+const selectedTitle = computed(() => isNew.value ? '新增規則集' : (selected.value?.displayName ?? '選擇規則集'));
+
 watch(() => props.visible, async (v) => {
     if (v) {
         await load();
@@ -37,11 +41,23 @@ watch(() => props.visible, async (v) => {
 <template>
     <Teleport to="body">
         <div v-if="visible" class="modal-overlay" @click.self="emit('close')">
-            <div class="modal">
-                <div class="modal-header">
-                    <span class="modal-title">管理標籤規則集</span>
-                    <button class="close-btn" @click="emit('close')">✕</button>
-                </div>
+            <div class="modal" role="dialog" aria-modal="true" aria-labelledby="rule-set-modal-title">
+                <header class="modal-header">
+                    <div class="title-block">
+                        <span class="modal-eyebrow">Automation presets</span>
+                        <h2 id="rule-set-modal-title">標籤規則集工作台</h2>
+                        <p>建立自動套標籤的規則集。規則集可被資料夾預設引用，但不會改變資料夾本身。</p>
+                    </div>
+                    <div class="header-side">
+                        <div class="summary-pills" aria-label="規則集摘要">
+                            <span><strong>{{ itemTypes.length }}</strong> 規則集</span>
+                            <span><strong>{{ customRuleSets }}</strong> 自訂</span>
+                            <span><strong>{{ totalRules }}</strong> 規則</span>
+                        </div>
+                        <button type="button" class="close-btn" aria-label="關閉" @click="emit('close')">✕</button>
+                    </div>
+                </header>
+
                 <div class="modal-body">
                     <CategoryList
                         :itemTypes="itemTypes"
@@ -52,17 +68,23 @@ watch(() => props.visible, async (v) => {
                         @delete="deleteType"
                     />
 
-                    <CategoryEditor
-                        :isNew="isNew"
-                        :saving="saving"
-                        :form="form"
-                        v-model:extInput="extInput"
-                        @addExt="addExt"
-                        @removeExt="removeExt"
-                        @addRule="addRule"
-                        @removeRule="removeRule"
-                        @save="save"
-                    />
+                    <section class="editor-shell" aria-label="規則集編輯區">
+                        <div class="editor-context">
+                            <span class="context-label">正在編輯</span>
+                            <strong>{{ selectedTitle }}</strong>
+                        </div>
+                        <CategoryEditor
+                            :isNew="isNew"
+                            :saving="saving"
+                            :form="form"
+                            v-model:extInput="extInput"
+                            @addExt="addExt"
+                            @removeExt="removeExt"
+                            @addRule="addRule"
+                            @removeRule="removeRule"
+                            @save="save"
+                        />
+                    </section>
                 </div>
             </div>
         </div>
@@ -73,50 +95,193 @@ watch(() => props.visible, async (v) => {
 .modal-overlay {
     position: fixed;
     inset: 0;
-    background: var(--bg-scrim);
+    background: var(--bg-scrim-heavy);
     display: flex;
     align-items: center;
     justify-content: center;
     z-index: 2100;
+    padding: 24px;
 }
+
 .modal {
-    background: var(--bg-panel);
-    border: 1px solid var(--border-default);
-    border-radius: 14px;
-    width: 640px;
-    max-width: 95vw;
-    max-height: 80vh;
+    width: min(1040px, 96vw);
+    max-height: min(88vh, 860px);
     display: flex;
     flex-direction: column;
     overflow: hidden;
+    background:
+        radial-gradient(circle at 0% 0%, var(--accent-bg-subtle), transparent 36%),
+        var(--bg-panel);
+    border: 1px solid var(--border-default);
+    border-radius: 18px;
     box-shadow: var(--shadow-modal);
 }
+
 .modal-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 20px;
+    padding: 22px 24px 18px;
+    border-bottom: 1px solid var(--border-subtle);
+    flex-shrink: 0;
+}
+
+.title-block,
+.header-side,
+.editor-shell {
+    min-width: 0;
+}
+
+.modal-eyebrow,
+.context-label {
+    font-family: var(--font-mono);
+    font-size: 0.66rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--text-tertiary);
+}
+
+.title-block h2 {
+    margin: 7px 0 8px;
+    color: var(--text-primary);
+    font-size: clamp(1.35rem, 2.4vw, 2rem);
+    line-height: 1.05;
+    letter-spacing: -0.03em;
+}
+
+.title-block p {
+    max-width: 640px;
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    line-height: 1.6;
+}
+
+.header-side {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    flex-shrink: 0;
+}
+
+.summary-pills {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 6px;
+    min-width: 0;
+}
+
+.summary-pills span {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 5px 8px;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-pill);
+    color: var(--text-secondary);
+    background: var(--bg-overlay-soft);
+    font-size: 0.72rem;
+    white-space: nowrap;
+}
+
+.summary-pills strong {
+    color: var(--text-primary);
+}
+
+.close-btn {
+    flex-shrink: 0;
+    width: 32px;
+    height: 32px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--bg-overlay-soft);
+    border: 1px solid var(--border-default);
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    cursor: pointer;
+    border-radius: 50%;
+    transition: background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.close-btn:hover {
+    color: var(--text-primary);
+    background: var(--bg-overlay-strong);
+    border-color: var(--border-strong);
+}
+
+.modal-body {
+    display: grid;
+    grid-template-columns: minmax(0, 0.38fr) minmax(0, 1fr);
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+}
+
+.editor-shell {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    border-left: 1px solid var(--border-subtle);
+    background: color-mix(in srgb, var(--bg-app) 18%, transparent);
+}
+
+.editor-context {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 16px 20px;
-    border-bottom: 1px solid var(--border-default);
-    flex-shrink: 0;
-}
-.modal-title {
-    font-size: 1rem;
-    font-weight: 600;
+    gap: 12px;
+    padding: 12px 20px;
+    border-bottom: 1px solid var(--border-subtle);
     color: var(--text-primary);
+    flex-shrink: 0;
+    min-width: 0;
 }
-.close-btn {
-    background: transparent;
-    border: none;
-    color: var(--text-secondary);
-    font-size: 0.9rem;
-    cursor: pointer;
-    padding: 4px 6px;
-    border-radius: 4px;
-}
-.close-btn:hover { color: var(--text-primary); background: var(--bg-overlay-soft); }
-.modal-body {
-    display: flex;
-    flex: 1;
+
+.editor-context strong {
     overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 0.9rem;
+}
+
+@media (max-width: 820px) {
+    .modal-overlay {
+        align-items: stretch;
+        padding: 12px;
+    }
+
+    .modal {
+        width: 100%;
+        max-height: none;
+        height: 100%;
+        border-radius: 14px;
+    }
+
+    .modal-header {
+        flex-direction: column;
+    }
+
+    .header-side {
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    .summary-pills {
+        justify-content: flex-start;
+    }
+
+    .modal-body {
+        grid-template-columns: 1fr;
+        overflow-y: auto;
+    }
+
+    .editor-shell {
+        border-left: none;
+        border-top: 1px solid var(--border-subtle);
+        overflow: visible;
+    }
 }
 </style>

--- a/src/components/CategoryManageModal.vue
+++ b/src/components/CategoryManageModal.vue
@@ -39,7 +39,7 @@ watch(() => props.visible, async (v) => {
         <div v-if="visible" class="modal-overlay" @click.self="emit('close')">
             <div class="modal">
                 <div class="modal-header">
-                    <span class="modal-title">管理類別</span>
+                    <span class="modal-title">管理標籤規則集</span>
                     <button class="close-btn" @click="emit('close')">✕</button>
                 </div>
                 <div class="modal-body">

--- a/src/components/ComicSlideReader.vue
+++ b/src/components/ComicSlideReader.vue
@@ -36,7 +36,7 @@ const canAutoplay = computed(() => pages.value.length > 1 && !isLoading.value &&
 const pageLabel = computed(() =>
   pages.value.length > 0 ? `${pageIndex.value + 1} / ${pages.value.length}` : '0 / 0'
 );
-const readerModeLabel = computed(() => props.item?.itemType === 'folder' ? 'COMIC FOLDER' : 'ARCHIVE READER');
+const readerModeLabel = computed(() => props.item?.itemType === 'folder' ? 'FOLDER READER' : 'ARCHIVE READER');
 const autoplayLabel = computed(() => `${autoplaySeconds.value.toFixed(1)} 秒/頁`);
 const autoplayButtonLabel = computed(() => isAutoplaying.value ? '停止播放' : '自動播放');
 const canFullscreen = computed(() =>

--- a/src/components/FileExplorerTable.vue
+++ b/src/components/FileExplorerTable.vue
@@ -245,7 +245,7 @@ const { applyRulesForItem } = useFolderRuleActions(
 const getFileIcon = (item: FileItem): string => {
   const dbItem = getDbItem(item, props.itemByPath);
   if (item.isDir) {
-    return getTypeConfig(dbItem?.category).icon;
+    return '📁';
   }
   if (dbItem?.category && dbItem.category !== 'default') {
     return getTypeConfig(dbItem.category).icon;
@@ -421,8 +421,8 @@ const {
       <template v-if="contextMenu.item?.isDir">
         <button class="ctx-item" @click="emit('dblclick', contextMenu.item!); hideContextMenu()">進入資料夾</button>
         <button v-if="contextMenu.item && canRead(contextMenu.item)" class="ctx-item" @click="emit('read', contextMenu.item!); hideContextMenu()">開啟閱讀模式</button>
-        <button class="ctx-item" @click="emit('detail', contextMenu.item!); hideContextMenu()">{{ hasCategoryAssigned(contextMenu.item!, props.itemByPath) ? '修改類別' : '新增類別' }}</button>
-        <button class="ctx-item" @click="applyRulesForItem(contextMenu.item!)">重新套用類別</button>
+        <button class="ctx-item" @click="emit('detail', contextMenu.item!); hideContextMenu()">編輯標籤</button>
+        <button class="ctx-item" @click="applyRulesForItem(contextMenu.item!)">套用標籤規則</button>
         <button class="ctx-item" @click="startRename">修改檔名</button>
         <div class="ctx-divider"></div>
         <button class="ctx-item ctx-danger" @click="emit('delete', contextMenu.item!); hideContextMenu()">移至資源回收筒</button>
@@ -431,7 +431,7 @@ const {
         <button v-if="contextMenu.item && canRead(contextMenu.item)" class="ctx-item" @click="emit('read', contextMenu.item!); hideContextMenu()">開啟閱讀模式</button>
         <button class="ctx-item" @click="emit('detail', contextMenu.item!); hideContextMenu()">詳情/編輯標籤</button>
         <button class="ctx-item" @click="emit('addCategory', contextMenu.item!); hideContextMenu()">{{ hasCategoryAssigned(contextMenu.item!, props.itemByPath) ? '修改類別' : '新增類別' }}</button>
-        <button class="ctx-item" @click="applyRulesForItem(contextMenu.item!)">重新套用類別</button>
+        <button class="ctx-item" @click="applyRulesForItem(contextMenu.item!)">套用標籤規則</button>
         <button class="ctx-item" @click="startRename">修改檔名</button>
         <div class="ctx-divider"></div>
         <button class="ctx-item ctx-danger" @click="emit('delete', contextMenu.item!); hideContextMenu()">移至資源回收筒</button>

--- a/src/components/FolderDetailModal.vue
+++ b/src/components/FolderDetailModal.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue';
-import { api, type Item, type Tag } from '../api';
+import { computed, ref, watch } from 'vue';
+import { api, type Item, type Tag, type FolderRulePreset } from '../api';
 import { useTagManager } from '../composables/useTagManager';
 import { useToast } from '../composables/useToast';
 import { useItemTypes } from '../composables/useItemTypes';
@@ -19,11 +19,20 @@ const emit = defineEmits<{
 }>();
 
 const { show: showToast, confirm: confirmDialog } = useToast();
-const { itemTypes, getTypeConfig } = useItemTypes();
+const { itemTypes, load: loadItemTypes } = useItemTypes();
 const editName = ref('');
 const editNote = ref('');
-const editType = ref('default');
 const isSaving = ref(false);
+const isSavingPreset = ref(false);
+const isApplyingPreset = ref(false);
+const rulePreset = ref<FolderRulePreset | null>(null);
+const selectedRulePresetId = ref<number | null>(null);
+const rulePresetOptions = computed(() => itemTypes.value.filter(t => t.tagRules?.length));
+const selectedRulePreset = computed(() => (
+  selectedRulePresetId.value == null
+    ? null
+    : itemTypes.value.find(t => t.id === selectedRulePresetId.value) ?? null
+));
 
 const { localTags, tagInput, suggestions: tagInputSuggestions, showSuggestions: showTagInputSuggestions,
     initTags, onInputChange: onTagInputChange, submitInput: submitTagInput,
@@ -35,14 +44,61 @@ const { localTags, tagInput, suggestions: tagInputSuggestions, showSuggestions: 
     onUpdated: () => emit('updated'),
 });
 
-watch(() => props.item, (item) => {
+watch(() => props.item, async (item) => {
   if (item) {
     initTags(item.tags);
     editName.value = item.name;
     editNote.value = item.note ?? '';
-    editType.value = item.category ?? 'default';
+    await loadItemTypes();
+    rulePreset.value = await api.getFolderRulePreset(item.id);
+    selectedRulePresetId.value = rulePreset.value?.presetTypeId ?? null;
   }
 }, { immediate: true });
+
+const saveRulePreset = async () => {
+  if (!props.item || isSavingPreset.value) return;
+  isSavingPreset.value = true;
+  try {
+    if (selectedRulePresetId.value == null) {
+      await api.clearFolderRulePreset(props.item.id);
+      rulePreset.value = null;
+      showToast('已清除預設標籤規則集', 'success');
+    } else {
+      rulePreset.value = await api.setFolderRulePreset({
+        folderItemId: props.item.id,
+        presetTypeId: selectedRulePresetId.value,
+        applyToSubfolders: false,
+        applyToFiles: false,
+        fileExtensions: [],
+      });
+      showToast('已儲存預設標籤規則集', 'success');
+    }
+    emit('updated');
+  } catch (e) {
+    showToast('儲存預設規則集失敗: ' + String(e), 'error');
+  } finally {
+    isSavingPreset.value = false;
+  }
+};
+
+const applySelectedRulePreset = async () => {
+  if (!props.item || isApplyingPreset.value) return;
+  const preset = selectedRulePreset.value;
+  if (!preset?.tagRules?.length) {
+    showToast('此規則集沒有可套用的標籤規則', 'info');
+    return;
+  }
+  isApplyingPreset.value = true;
+  try {
+    const result = await api.applyRulesToItem(props.item.id, preset.tagRules);
+    showToast(`已套用 ${result.tagged} 個標籤`, 'success');
+    emit('updated');
+  } catch (e) {
+    showToast('套用預設規則集失敗: ' + String(e), 'error');
+  } finally {
+    isApplyingPreset.value = false;
+  }
+};
 
 const saveChanges = async () => {
   if (!props.item || isSaving.value) return;
@@ -51,10 +107,8 @@ const saveChanges = async () => {
     const item = props.item;
     const newName = editName.value.trim();
     const newNote = editNote.value.trim();
-    const newCategory = editType.value;
     await Promise.all([
       newName !== item.name ? api.setItemDisplayName(item.id, newName) : Promise.resolve(),
-      newCategory !== (item.category ?? 'default') ? api.setItemCategory(item.id, newCategory) : Promise.resolve(),
       newNote !== (item.note ?? '') ? api.setItemNote(item.id, newNote) : Promise.resolve(),
     ]);
     emit('updated');
@@ -92,21 +146,12 @@ const openFolder = async () => {
   >
     <template #left>
       <div class="folder-icon-area">
-        <span class="big-icon">{{ getTypeConfig(item.category).icon }}</span>
+        <span class="big-icon">📁</span>
       </div>
 
       <div class="info-block">
         <label>名稱</label>
         <input v-model="editName" class="edit-input" @blur="saveChanges" @keydown.enter="saveChanges" />
-      </div>
-
-      <div class="info-block">
-        <label>類別</label>
-        <select v-model="editType" class="edit-input" @change="saveChanges">
-          <option v-for="t in itemTypes" :key="t.name" :value="t.name">
-            {{ t.icon }} {{ t.displayName }}
-          </option>
-        </select>
       </div>
 
       <div class="info-block">
@@ -128,6 +173,23 @@ const openFolder = async () => {
     </template>
 
     <template #right>
+      <div class="actions">
+        <h3>自動化</h3>
+        <label class="preset-label">預設標籤規則集</label>
+        <select v-model="selectedRulePresetId" class="preset-select" :disabled="isSavingPreset || isApplyingPreset">
+          <option :value="null">未設定</option>
+          <option v-for="t in rulePresetOptions" :key="t.id" :value="t.id">
+            {{ t.icon }} {{ t.displayName }}
+          </option>
+        </select>
+        <button class="btn-open" :disabled="isSavingPreset" @click="saveRulePreset">
+          {{ isSavingPreset ? '儲存中...' : '儲存預設規則集' }}
+        </button>
+        <button class="btn-open" :disabled="!selectedRulePreset || isApplyingPreset" @click="applySelectedRulePreset">
+          {{ isApplyingPreset ? '套用中...' : '立即套用' }}
+        </button>
+      </div>
+
       <div class="actions">
         <h3>操作</h3>
         <button class="btn-open" @click="openFolder">📂 用系統開啟</button>
@@ -170,8 +232,26 @@ const openFolder = async () => {
 .edit-input:focus { border-color: var(--accent); }
 .edit-textarea { resize: vertical; }
 
-.actions { display: flex; flex-direction: column; gap: 10px; }
+.actions { display: flex; flex-direction: column; gap: 10px; margin-bottom: 18px; }
 .actions h3 { margin-bottom: 10px; padding-bottom: 10px; border-bottom: 1px solid var(--border-default); }
+
+.preset-label {
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+}
+
+.preset-select {
+  min-width: 0;
+  width: 100%;
+  background: var(--bg-input);
+  border: 1px solid var(--border-default);
+  border-radius: 6px;
+  color: var(--text-primary);
+  padding: 8px 10px;
+  font-size: 0.9rem;
+  outline: none;
+}
+.preset-select:focus { border-color: var(--accent); }
 
 .btn-open, .btn-delete {
   padding: 10px 16px;

--- a/src/components/ItemCategoryModal.vue
+++ b/src/components/ItemCategoryModal.vue
@@ -29,7 +29,7 @@ const saveCategory = async () => {
   isSaving.value = true;
   try {
     await api.setItemCategory(props.item.id, editType.value);
-    // 改完類別後自動套用該類別的 tag rules，使用者不必再手動按「重新套用類別」
+    // 改完檔案分類後自動套用對應標籤規則，使用者不必再手動按「套用標籤規則」
     const type = itemTypes.value.find(t => t.name === editType.value);
     if (type?.tagRules?.length) {
       await api.applyRulesToItem(props.item.id, type.tagRules);

--- a/src/components/ItemGallery.vue
+++ b/src/components/ItemGallery.vue
@@ -14,7 +14,7 @@ import { useGalleryViewState } from '../composables/useGalleryViewState';
 import { useGalleryPreviewResize } from '../composables/useGalleryPreviewResize';
 import { formatSize } from '../utils/format';
 import { pathKey } from '../utils/pathKey';
-import { isComicFolderItem, isReadableArchiveItem, isReadableFileItem } from '../utils/readableItem';
+import { isReadableArchiveItem, isReadableFileItem } from '../utils/readableItem';
 
 const props = defineProps<{
   sourcePath: string | null;
@@ -201,7 +201,6 @@ const getOrImportDbItem = async (fileItem: FileItem): Promise<Item | null> => {
 
 const openReaderForFileItem = async (fileItem: FileItem): Promise<boolean> => {
   const existing = findDbItemForFileItem(fileItem);
-  if (fileItem.isDir && !isComicFolderItem(existing)) return false;
   if (!fileItem.isDir && !isReadableArchiveItem(fileItem)) return false;
 
   if (!fileItem.isDir) {
@@ -216,11 +215,14 @@ const openReaderForFileItem = async (fileItem: FileItem): Promise<boolean> => {
 };
 
 const handleFileItemDblClick = async (item: FileItem) => {
-  if (await openReaderForFileItem(item)) return;
-
   if (item.isDir) {
     emit('navigateDir', item.path);
-  } else if (ARCHIVE_EXTS.includes(item.extension?.toLowerCase() ?? '')) {
+    return;
+  }
+
+  if (await openReaderForFileItem(item)) return;
+
+  if (ARCHIVE_EXTS.includes(item.extension?.toLowerCase() ?? '')) {
     api.openFile(item.path);
   } else {
     const dbItem = itemByPath.value.get(pathKey(item.path));

--- a/src/components/SettingsPanel.vue
+++ b/src/components/SettingsPanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { computed, ref, onMounted } from 'vue';
 import { api } from '../api';
 import { useItemTypes } from '../composables/useItemTypes';
 import { useThemeStore, type ThemeId } from '../stores/themeStore';
@@ -13,13 +13,16 @@ const emit = defineEmits<{
   (e: 'tagsChanged'): void;
 }>();
 
-const { load: loadItemTypes } = useItemTypes();
+type SettingsSectionId = 'automation' | 'appearance' | 'system';
+
+const { itemTypes, load: loadItemTypes } = useItemTypes();
 const themeStore = useThemeStore();
 const fontSizeStore = useFontSizeStore();
 const { show: showToast, confirm: confirmDialog } = useToast();
 const { loadTags } = useTags();
 
 const showCategoryManage = ref(false);
+const activeSection = ref<SettingsSectionId>('automation');
 
 const isDeletingEmptyTags = ref(false);
 
@@ -77,114 +80,232 @@ const onClearDebugLog = async () => {
 
 onMounted(async () => {
   try {
-    [debugMode.value, debugLogPath.value] = await Promise.all([
+    const [nextDebugMode, nextDebugLogPath] = await Promise.all([
       api.getDebugMode(),
       api.getDebugLogPath(),
+      loadItemTypes(),
     ]);
+    debugMode.value = nextDebugMode;
+    debugLogPath.value = nextDebugLogPath;
   } catch (e) {
-    console.error('[SettingsPanel] load debug state failed', e);
+    console.error('[SettingsPanel] load settings state failed', e);
   }
 });
 
-const fontSizes: { id: FontSize; label: string }[] = [
-  { id: 'small',  label: '小' },
-  { id: 'medium', label: '中' },
-  { id: 'large',  label: '大' },
+const fontSizes: { id: FontSize; label: string; detail: string }[] = [
+  { id: 'small',  label: '小', detail: '高密度清單' },
+  { id: 'medium', label: '中', detail: '平衡閱讀' },
+  { id: 'large',  label: '大', detail: '遠距觀看' },
 ];
 
-const themes: { id: ThemeId; label: string; color: string }[] = [
-  { id: 'obsidian',  label: 'Obsidian · Amber',    color: '#f0b429' },
-  { id: 'forge',     label: 'Forge · Industrial',  color: '#ff6b35' },
-  { id: 'parchment', label: 'Parchment · Archive', color: '#b0431e' },
-  { id: 'phosphor',  label: 'Phosphor · Terminal', color: '#00ff41' },
+const themes: { id: ThemeId; label: string; detail: string; color: string }[] = [
+  { id: 'obsidian',  label: 'Obsidian · Amber',    detail: '暗色琥珀，高對比工作台', color: '#f0b429' },
+  { id: 'forge',     label: 'Forge · Industrial',  detail: '工業深灰，銳利邊界', color: '#ff6b35' },
+  { id: 'parchment', label: 'Parchment · Archive', detail: '暖色紙本，適合長時間整理', color: '#b0431e' },
+  { id: 'phosphor',  label: 'Phosphor · Terminal', detail: '終端機綠光，極簡資訊密度', color: '#00ff41' },
 ];
+
+const settingsSections: { id: SettingsSectionId; eyebrow: string; title: string; description: string }[] = [
+  {
+    id: 'automation',
+    eyebrow: 'Tags & automation',
+    title: '標籤與自動化',
+    description: '維護標籤規則集、清理空標籤；規則只負責輔助套標，不改變資料夾本身。',
+  },
+  {
+    id: 'appearance',
+    eyebrow: 'Appearance',
+    title: '外觀與閱讀密度',
+    description: '調整字型大小與主題，讓資料整理介面符合你的工作距離。',
+  },
+  {
+    id: 'system',
+    eyebrow: 'System',
+    title: '系統與診斷',
+    description: '語言、Debug log 與低階診斷入口。',
+  },
+];
+
+const currentSection = computed(() => settingsSections.find(section => section.id === activeSection.value) ?? settingsSections[0]);
+const currentThemeLabel = computed(() => themes.find(theme => theme.id === themeStore.current)?.label ?? themeStore.current);
+const ruleSetCount = computed(() => itemTypes.value.length);
+const builtinRuleSetCount = computed(() => itemTypes.value.filter(type => type.isBuiltin).length);
+const customRuleSetCount = computed(() => itemTypes.value.filter(type => !type.isBuiltin).length);
+const totalRuleCount = computed(() => itemTypes.value.reduce((sum, type) => sum + type.tagRules.length, 0));
 </script>
 
 <template>
-  <div class="panel">
-    <div class="panel-header">
-      <h2>設定</h2>
-    </div>
-    <div class="panel-body">
+  <div class="settings-panel">
+    <header class="settings-hero">
+      <div class="hero-copy">
+        <span class="eyebrow">Settings</span>
+        <h2>設定中心</h2>
+        <p>把外觀、標籤規則集與診斷工具分開管理；資料夾維持單純容器，語意交給標籤。</p>
+      </div>
+      <div class="hero-metrics" aria-label="設定摘要">
+        <span class="metric-pill"><strong>{{ ruleSetCount }}</strong> 規則集</span>
+        <span class="metric-pill"><strong>{{ totalRuleCount }}</strong> 自動規則</span>
+        <span class="metric-pill accent-pill">{{ currentThemeLabel }}</span>
+      </div>
+    </header>
 
-      <section class="section">
-        <h3 class="section-title">管理</h3>
-        <button class="manage-btn" @click="showCategoryManage = true">
-          <svg viewBox="0 0 24 24" fill="currentColor" class="btn-icon">
-            <path d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.09.63-.09.94s.02.64.07.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z"/>
-          </svg>
-          管理標籤規則集
+    <div class="settings-shell">
+      <aside class="settings-rail" aria-label="設定分類">
+        <button
+          v-for="section in settingsSections"
+          :key="section.id"
+          type="button"
+          class="rail-item"
+          :class="{ active: activeSection === section.id }"
+          @click="activeSection = section.id"
+        >
+          <span class="rail-eyebrow">{{ section.eyebrow }}</span>
+          <span class="rail-title">{{ section.title }}</span>
         </button>
-        <button class="manage-btn" :disabled="isDeletingEmptyTags" @click="handleDeleteEmptyTags">
-          <svg viewBox="0 0 24 24" fill="currentColor" class="btn-icon">
-            <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/>
-          </svg>
-          {{ isDeletingEmptyTags ? '刪除中...' : '刪除空標籤' }}
-        </button>
-      </section>
+      </aside>
 
-      <section class="section">
-        <h3 class="section-title">顯示</h3>
-
-        <div class="field">
-          <label class="field-label">字型大小</label>
-          <div class="seg">
-            <button
-              v-for="s in fontSizes"
-              :key="s.id"
-              class="seg-btn"
-              :class="{ active: fontSizeStore.current === s.id }"
-              @click="fontSizeStore.setFontSize(s.id)"
-            >{{ s.label }}</button>
-          </div>
+      <main class="settings-content">
+        <div class="section-intro">
+          <span class="eyebrow">{{ currentSection.eyebrow }}</span>
+          <h3>{{ currentSection.title }}</h3>
+          <p>{{ currentSection.description }}</p>
         </div>
 
-        <div class="field">
-          <label class="field-label">主題風格</label>
-          <div class="theme-list">
-            <button
-              v-for="t in themes"
-              :key="t.id"
-              class="theme-option"
-              :class="{ active: themeStore.current === t.id }"
-              @click="themeStore.setTheme(t.id)"
-            >
-              <span class="theme-swatch" :style="{ background: t.color }"></span>
-              <span class="theme-label">{{ t.label }}</span>
-              <span v-if="themeStore.current === t.id" class="theme-check">✓</span>
+        <section v-if="activeSection === 'automation'" class="card-grid card-grid--automation">
+          <article class="settings-card featured-card">
+            <div class="card-header">
+              <div>
+                <span class="card-kicker">Automation library</span>
+                <h4>標籤規則集</h4>
+              </div>
+              <span class="card-count">{{ ruleSetCount }}</span>
+            </div>
+            <p class="card-copy">
+              規則集是套標籤的自動化模板，可被資料夾預設引用；它不改變資料夾本身。
+            </p>
+            <div class="stat-row">
+              <span><strong>{{ builtinRuleSetCount }}</strong> 內建</span>
+              <span><strong>{{ customRuleSetCount }}</strong> 自訂</span>
+              <span><strong>{{ totalRuleCount }}</strong> 規則</span>
+            </div>
+            <button type="button" class="primary-action" @click="showCategoryManage = true">
+              管理規則集
             </button>
-          </div>
-        </div>
-      </section>
+          </article>
 
-      <section class="section">
-        <h3 class="section-title">語言</h3>
-        <div class="field">
-          <select class="lang-select" disabled>
-            <option>繁體中文</option>
-          </select>
-          <span class="hint">i18n 規劃中</span>
-        </div>
-      </section>
+          <article class="settings-card">
+            <div class="card-header">
+              <div>
+                <span class="card-kicker">Tag hygiene</span>
+                <h4>清理空標籤</h4>
+              </div>
+            </div>
+            <p class="card-copy">
+              移除沒有連到任何檔案或資料夾的標籤，保留所有內容與資料夾本身。
+            </p>
+            <button
+              type="button"
+              class="secondary-action danger-action"
+              :disabled="isDeletingEmptyTags"
+              @click="handleDeleteEmptyTags"
+            >
+              {{ isDeletingEmptyTags ? '刪除中...' : '刪除空標籤' }}
+            </button>
+          </article>
+        </section>
 
-      <section class="section">
-        <h3 class="section-title">Debug 模式</h3>
-        <div class="field">
-          <label class="debug-toggle">
-            <input type="checkbox" v-model="debugMode" @change="onToggleDebug" />
-            <span>啟用 debug log（關鍵 mutation 操作會寫入日誌檔）</span>
-          </label>
-        </div>
-        <div class="field">
-          <label class="field-label">日誌路徑</label>
-          <span class="debug-path" :title="debugLogPath">{{ debugLogPath || '—' }}</span>
-        </div>
-        <div class="field debug-actions">
-          <button class="debug-btn" @click="onOpenDebugLog">開啟日誌</button>
-          <button class="debug-btn debug-btn-danger" @click="onClearDebugLog">清空日誌</button>
-        </div>
-      </section>
+        <section v-else-if="activeSection === 'appearance'" class="card-grid">
+          <article class="settings-card">
+            <div class="card-header">
+              <div>
+                <span class="card-kicker">Density</span>
+                <h4>字型大小</h4>
+              </div>
+            </div>
+            <div class="density-options" role="group" aria-label="字型大小">
+              <button
+                v-for="size in fontSizes"
+                :key="size.id"
+                type="button"
+                class="density-option"
+                :class="{ active: fontSizeStore.current === size.id }"
+                @click="fontSizeStore.setFontSize(size.id)"
+              >
+                <span class="density-label">{{ size.label }}</span>
+                <span class="density-detail">{{ size.detail }}</span>
+              </button>
+            </div>
+          </article>
 
+          <article class="settings-card wide-card">
+            <div class="card-header">
+              <div>
+                <span class="card-kicker">Theme</span>
+                <h4>主題風格</h4>
+              </div>
+            </div>
+            <div class="theme-grid">
+              <button
+                v-for="theme in themes"
+                :key="theme.id"
+                type="button"
+                class="theme-card"
+                :class="{ active: themeStore.current === theme.id }"
+                @click="themeStore.setTheme(theme.id)"
+              >
+                <span class="theme-swatch" :style="{ background: theme.color }"></span>
+                <span class="theme-copy">
+                  <span class="theme-label">{{ theme.label }}</span>
+                  <span class="theme-detail">{{ theme.detail }}</span>
+                </span>
+                <span v-if="themeStore.current === theme.id" class="theme-check">✓</span>
+              </button>
+            </div>
+          </article>
+        </section>
+
+        <section v-else class="card-grid">
+          <article class="settings-card">
+            <div class="card-header">
+              <div>
+                <span class="card-kicker">Language</span>
+                <h4>語言</h4>
+              </div>
+            </div>
+            <div class="field-stack">
+              <select class="field-control" disabled>
+                <option>繁體中文</option>
+              </select>
+              <span class="field-hint">i18n 規劃中，目前固定繁體中文。</span>
+            </div>
+          </article>
+
+          <article class="settings-card wide-card">
+            <div class="card-header">
+              <div>
+                <span class="card-kicker">Diagnostics</span>
+                <h4>Debug 模式</h4>
+              </div>
+              <span class="status-pill" :class="{ active: debugMode }">{{ debugMode ? 'ON' : 'OFF' }}</span>
+            </div>
+            <label class="debug-toggle">
+              <input type="checkbox" v-model="debugMode" @change="onToggleDebug" />
+              <span>
+                <strong>啟用 debug log</strong>
+                <small>關鍵 mutation 操作會寫入日誌檔，方便追查資料異常。</small>
+              </span>
+            </label>
+            <div class="log-path-card">
+              <span class="field-label">日誌路徑</span>
+              <span class="debug-path" :title="debugLogPath">{{ debugLogPath || '—' }}</span>
+            </div>
+            <div class="button-row">
+              <button type="button" class="secondary-action" @click="onOpenDebugLog">開啟日誌</button>
+              <button type="button" class="secondary-action danger-action" @click="onClearDebugLog">清空日誌</button>
+            </div>
+          </article>
+        </section>
+      </main>
     </div>
   </div>
 
@@ -192,190 +313,539 @@ const themes: { id: ThemeId; label: string; color: string }[] = [
 </template>
 
 <style scoped>
-.panel {
+.settings-panel {
   display: flex;
   flex-direction: column;
   height: 100%;
   overflow: hidden;
+  background:
+    radial-gradient(circle at 16% 0%, var(--accent-bg-subtle), transparent 30%),
+    var(--bg-app);
 }
 
-.panel-header {
-  padding: 20px 32px 12px;
+.settings-hero {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 32px 40px 24px;
   border-bottom: 1px solid var(--border-subtle);
   flex-shrink: 0;
 }
 
-.panel-header h2 {
+.hero-copy,
+.section-intro,
+.card-header > div,
+.theme-copy,
+.debug-toggle span {
+  min-width: 0;
+}
+
+.eyebrow,
+.card-kicker,
+.rail-eyebrow {
   font-family: var(--font-mono);
-  font-size: 9px;
   text-transform: uppercase;
   letter-spacing: 0.14em;
   color: var(--text-tertiary);
+  font-size: 0.65rem;
   font-weight: 500;
 }
 
-.panel-body {
-  padding: 24px 32px;
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
-  overflow-y: auto;
-  max-width: 640px;
+.settings-hero h2,
+.section-intro h3,
+.settings-card h4 {
+  margin: 0;
+  color: var(--text-primary);
+  letter-spacing: -0.02em;
 }
 
-.section {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
+.settings-hero h2 {
+  margin-top: 8px;
+  font-size: clamp(1.9rem, 3vw, 3rem);
+  line-height: 1;
+  font-weight: 600;
 }
 
-.section-title {
-  font-family: var(--font-mono);
-  font-size: 9px;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: var(--text-tertiary);
-  font-weight: 500;
-}
-
-.field {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.field-label {
-  font-size: 0.78rem;
+.settings-hero p,
+.section-intro p,
+.card-copy,
+.field-hint {
   color: var(--text-secondary);
+  line-height: 1.6;
 }
 
-/* 管理標籤規則集按鈕 */
-.manage-btn {
+.settings-hero p {
+  max-width: 720px;
+  margin: 12px 0 0;
+  font-size: 0.95rem;
+}
+
+.hero-metrics {
   display: flex;
-  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
   gap: 8px;
-  width: 100%;
-  padding: 9px 12px;
-  border-radius: var(--radius-md);
-  font-size: 0.85rem;
-  font-weight: 500;
-  font-family: var(--font-mono);
-  background: transparent;
-  border: 1px solid var(--border-default);
-  color: var(--text-secondary);
-  cursor: pointer;
-  transition: background var(--transition-fast), color var(--transition-fast);
-  text-align: left;
+  min-width: 0;
 }
-.manage-btn:hover { background: var(--bg-overlay-soft); color: var(--text-primary); }
-.btn-icon { width: 16px; height: 16px; flex-shrink: 0; }
 
-/* segmented 控制 */
-.seg {
-  display: flex;
-  background: var(--bg-overlay-soft);
+.metric-pill,
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   border: 1px solid var(--border-default);
-  border-radius: var(--radius-md);
-  padding: 2px;
-  gap: 2px;
-}
-.seg-btn {
-  flex: 1;
-  background: transparent;
-  border: none;
+  background: var(--bg-overlay-soft);
   color: var(--text-secondary);
-  font-size: 0.82rem;
-  padding: 5px 0;
-  border-radius: 4px;
-  cursor: pointer;
-  transition: background var(--transition-fast), color var(--transition-fast);
+  border-radius: var(--radius-pill);
+  padding: 6px 10px;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  white-space: nowrap;
 }
-.seg-btn:hover { color: var(--text-primary); }
-.seg-btn.active {
+
+.metric-pill strong,
+.stat-row strong {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.accent-pill,
+.status-pill.active {
+  border-color: var(--accent-border);
   background: var(--accent-bg-subtle);
   color: var(--accent);
 }
 
-/* 主題清單 */
-.theme-list {
+.settings-shell {
+  display: grid;
+  grid-template-columns: 220px minmax(0, 1fr);
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.settings-rail {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 24px 16px 24px 24px;
+  border-right: 1px solid var(--border-subtle);
+  background: color-mix(in srgb, var(--bg-panel) 82%, transparent);
+  overflow-y: auto;
+}
+
+.rail-item {
   display: flex;
   flex-direction: column;
   gap: 4px;
-}
-.theme-option {
-  display: flex;
-  align-items: center;
-  gap: 10px;
   width: 100%;
-  padding: 7px 10px;
-  background: transparent;
+  min-width: 0;
+  padding: 12px 14px;
   border: 1px solid transparent;
-  border-radius: 6px;
-  cursor: pointer;
-  color: var(--text-primary);
-  font-size: 0.82rem;
+  border-radius: var(--radius-lg);
+  background: transparent;
+  color: var(--text-secondary);
   text-align: left;
-  transition: background var(--transition-fast), border-color var(--transition-fast);
-}
-.theme-option:hover { background: var(--bg-overlay-soft); }
-.theme-option.active {
-  background: var(--accent-bg-subtle);
-  border-color: var(--accent);
-}
-.theme-swatch {
-  width: 14px;
-  height: 14px;
-  border-radius: 50%;
-  flex-shrink: 0;
-}
-.theme-label { flex: 1; }
-.theme-check { color: var(--accent); font-size: 0.85rem; flex-shrink: 0; }
-
-/* 語言 placeholder */
-.lang-select {
-  background: var(--bg-overlay-soft);
-  border: 1px solid var(--border-default);
-  color: var(--text-tertiary);
-  border-radius: 6px;
-  padding: 6px 10px;
-  font-size: 0.82rem;
-  cursor: not-allowed;
-}
-.hint {
-  font-size: 0.72rem;
-  color: var(--text-tertiary);
-  font-style: italic;
-}
-
-/* Debug section */
-.debug-toggle {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 0.82rem;
-  color: var(--text-primary);
   cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
 }
-.debug-toggle input[type="checkbox"] { accent-color: var(--accent); cursor: pointer; }
-.debug-path {
-  font-family: var(--font-mono);
-  font-size: 0.72rem;
-  color: var(--text-tertiary);
-  word-break: break-all;
+
+.rail-item:hover {
+  background: var(--bg-overlay-soft);
+  color: var(--text-primary);
+}
+
+.rail-item.active {
+  background: var(--accent-bg-subtle);
+  border-color: var(--accent-border);
+  color: var(--text-primary);
+}
+
+.rail-title {
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+.settings-content {
+  overflow-y: auto;
+  padding: 28px 40px 40px;
   min-width: 0;
 }
-.debug-actions { flex-direction: row; gap: 8px; }
-.debug-btn {
-  flex: 1;
-  padding: 6px 10px;
-  background: transparent;
-  border: 1px solid var(--border-default);
-  border-radius: var(--radius-sm);
-  color: var(--text-secondary);
-  font-size: 0.8rem;
-  cursor: pointer;
-  transition: background var(--transition-fast), color var(--transition-fast);
+
+.section-intro {
+  max-width: 760px;
+  margin-bottom: 20px;
 }
-.debug-btn:hover { background: var(--bg-overlay-soft); color: var(--text-primary); }
-.debug-btn-danger:hover { background: var(--color-danger-bg-subtle); color: var(--color-danger); border-color: var(--color-danger); }
+
+.section-intro h3 {
+  margin-top: 6px;
+  font-size: 1.35rem;
+}
+
+.section-intro p {
+  margin: 8px 0 0;
+  font-size: 0.9rem;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+  max-width: 1040px;
+}
+
+.card-grid--automation {
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 0.8fr);
+}
+
+.settings-card {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-width: 0;
+  padding: 18px;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--bg-elevated) 72%, transparent);
+  box-shadow: var(--shadow-sm);
+}
+
+.featured-card {
+  background:
+    linear-gradient(135deg, var(--accent-bg-subtle), transparent 58%),
+    color-mix(in srgb, var(--bg-elevated) 78%, transparent);
+}
+
+.wide-card {
+  grid-column: span 2;
+}
+
+.card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  min-width: 0;
+}
+
+.settings-card h4 {
+  margin-top: 4px;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.card-copy {
+  margin: 0;
+  font-size: 0.86rem;
+}
+
+.card-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  background: var(--accent-bg-subtle);
+  color: var(--accent);
+  font-family: var(--font-mono);
+  font-weight: 600;
+}
+
+.stat-row,
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-width: 0;
+}
+
+.stat-row span {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-pill);
+  padding: 6px 9px;
+  color: var(--text-secondary);
+  background: var(--bg-overlay-soft);
+  font-size: 0.78rem;
+}
+
+.primary-action,
+.secondary-action {
+  border-radius: var(--radius-md);
+  padding: 9px 12px;
+  font-size: 0.86rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast), opacity var(--transition-fast);
+}
+
+.primary-action {
+  align-self: flex-start;
+  border: 1px solid var(--accent-border);
+  background: var(--accent);
+  color: var(--text-on-accent);
+  box-shadow: var(--shadow-accent-elevated);
+}
+
+.primary-action:hover {
+  background: var(--accent-hover);
+}
+
+.secondary-action {
+  border: 1px solid var(--border-default);
+  background: transparent;
+  color: var(--text-secondary);
+}
+
+.secondary-action:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.secondary-action:hover:not(:disabled) {
+  border-color: var(--border-strong);
+  background: var(--bg-overlay-soft);
+  color: var(--text-primary);
+}
+
+.danger-action:hover:not(:disabled) {
+  border-color: var(--color-danger);
+  background: var(--color-danger-bg-subtle);
+  color: var(--color-danger);
+}
+
+.density-options {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.density-option,
+.theme-card {
+  min-width: 0;
+  border: 1px solid var(--border-default);
+  background: var(--bg-overlay-soft);
+  color: var(--text-secondary);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
+}
+
+.density-option {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px;
+  text-align: left;
+}
+
+.density-option:hover {
+  color: var(--text-primary);
+  border-color: var(--border-strong);
+}
+
+.density-option.active {
+  border-color: var(--accent-border);
+  background: var(--accent-bg-subtle);
+  color: var(--text-primary);
+}
+
+.density-label {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.density-detail,
+.theme-detail {
+  font-size: 0.75rem;
+  color: var(--text-tertiary);
+  line-height: 1.45;
+}
+
+.theme-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.theme-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px;
+  text-align: left;
+}
+
+.theme-card:hover {
+  color: var(--text-primary);
+  border-color: var(--border-strong);
+}
+
+.theme-card.active {
+  border-color: var(--accent-border);
+  background: var(--accent-bg-subtle);
+  color: var(--text-primary);
+}
+
+.theme-swatch {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  box-shadow: 0 0 0 3px var(--bg-overlay-soft);
+}
+
+.theme-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  flex: 1;
+}
+
+.theme-label {
+  color: var(--text-primary);
+  font-size: 0.86rem;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.theme-check {
+  color: var(--accent);
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.field-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+
+.field-control {
+  min-width: 0;
+  width: 100%;
+  background: var(--bg-input);
+  border: 1px solid var(--border-default);
+  color: var(--text-tertiary);
+  border-radius: var(--radius-md);
+  padding: 8px 10px;
+  font-size: 0.86rem;
+  cursor: not-allowed;
+}
+
+.field-hint {
+  font-size: 0.76rem;
+  margin: 0;
+}
+
+.debug-toggle {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  min-width: 0;
+  cursor: pointer;
+  color: var(--text-primary);
+}
+
+.debug-toggle input[type="checkbox"] {
+  flex-shrink: 0;
+  margin-top: 2px;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
+.debug-toggle strong,
+.debug-toggle small {
+  display: block;
+}
+
+.debug-toggle small {
+  margin-top: 4px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.log-path-card {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-overlay-soft);
+  border-radius: var(--radius-md);
+  padding: 10px 12px;
+}
+
+.field-label {
+  font-size: 0.74rem;
+  color: var(--text-tertiary);
+}
+
+.debug-path {
+  min-width: 0;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--text-secondary);
+  word-break: break-all;
+}
+
+@media (max-width: 900px) {
+  .settings-hero {
+    align-items: flex-start;
+    flex-direction: column;
+    padding: 28px 24px 20px;
+  }
+
+  .hero-metrics {
+    justify-content: flex-start;
+  }
+
+  .settings-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-rail {
+    flex-direction: row;
+    overflow-x: auto;
+    border-right: none;
+    border-bottom: 1px solid var(--border-subtle);
+    padding: 12px 16px;
+  }
+
+  .rail-item {
+    flex: 1 0 auto;
+  }
+
+  .settings-content {
+    padding: 24px;
+  }
+
+  .card-grid,
+  .card-grid--automation,
+  .theme-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .wide-card {
+    grid-column: auto;
+  }
+}
+
+@media (max-width: 620px) {
+  .density-options {
+    grid-template-columns: 1fr;
+  }
+
+  .button-row,
+  .primary-action,
+  .secondary-action {
+    width: 100%;
+  }
+}
 </style>

--- a/src/components/SettingsPanel.vue
+++ b/src/components/SettingsPanel.vue
@@ -113,7 +113,7 @@ const themes: { id: ThemeId; label: string; color: string }[] = [
           <svg viewBox="0 0 24 24" fill="currentColor" class="btn-icon">
             <path d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.09.63-.09.94s.02.64.07.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z"/>
           </svg>
-          管理類別
+          管理標籤規則集
         </button>
         <button class="manage-btn" :disabled="isDeletingEmptyTags" @click="handleDeleteEmptyTags">
           <svg viewBox="0 0 24 24" fill="currentColor" class="btn-icon">
@@ -249,7 +249,7 @@ const themes: { id: ThemeId; label: string; color: string }[] = [
   color: var(--text-secondary);
 }
 
-/* 管理類別按鈕 */
+/* 管理標籤規則集按鈕 */
 .manage-btn {
   display: flex;
   align-items: center;

--- a/src/components/SourcePanel.vue
+++ b/src/components/SourcePanel.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted, provide } from 'vue';
-import { api, type Tag, type Item, type FileItem } from '../api';
+import { api, type Tag, type Item, type FileItem, type FolderRulePreset, type ItemType } from '../api';
 import LocalDirTree from './LocalDirTree.vue';
 import { useTagManager } from '../composables/useTagManager';
 import { useToast } from '../composables/useToast';
@@ -15,14 +15,16 @@ const emit = defineEmits<{
 }>();
 
 const { show: showToast, confirm: confirmDialog } = useToast();
-const { itemTypes, load: loadItemTypes, getTypeConfig } = useItemTypes();
+const { itemTypes, load: loadItemTypes } = useItemTypes();
 // 右鍵選單
 const panelRef = ref<HTMLElement | null>(null);
 const ctxMenu = ref({ visible: false, x: 0, y: 0, path: '' });
 const showFolderModal = ref(false);
 const modalPhase = ref<'edit' | 'tags'>('edit');
 const folderInDb = ref<{ id: number } | null>(null);
-const editFolder = ref({ path: '', name: '', category: 'default' });
+const editFolder = ref({ path: '', name: '' });
+const selectedRulePresetId = ref<number | null>(null);
+const rememberRulePreset = ref(true);
 const applyToSubfolders = ref(false);
 const applyToSubfiles = ref(false);
 const subfileExtensionInput = ref('');
@@ -31,6 +33,14 @@ const progressDone = ref(0);
 const progressTotal = ref(0);
 const progressLabel = ref('');
 const allTags = ref<Tag[]>([]);
+const folderRulePresets = ref<FolderRulePreset[]>([]);
+
+const rulePresetOptions = computed(() => itemTypes.value.filter(t => t.tagRules?.length));
+const selectedRulePreset = computed(() => (
+  selectedRulePresetId.value == null
+    ? null
+    : itemTypes.value.find(t => t.id === selectedRulePresetId.value) ?? null
+));
 
 const progressPercent = computed(() => {
   if (progressTotal.value <= 0) return 0;
@@ -89,19 +99,24 @@ const openModifyTypeFromCtx = async () => {
   const p = ctxMenu.value.path;
   closeCtxMenu();
   await loadDbFolders();
+  await loadItemTypes();
   allTags.value = await api.getTags();
   const existing = dbFolders.value.find(f => f.path === p);
   if (existing) {
     folderInDb.value = { id: existing.id };
-    editFolder.value = { path: p, name: existing.name, category: existing.category ?? 'default' };
+    editFolder.value = { path: p, name: existing.name };
+    const preset = folderRulePresetByItemId.value.get(existing.id) ?? await api.getFolderRulePreset(existing.id);
+    selectedRulePresetId.value = preset?.presetTypeId ?? null;
+    rememberRulePreset.value = !!preset;
     initTags(existing.tags ?? []);
   } else {
     folderInDb.value = null;
     editFolder.value = {
       path: p,
       name: p.replace(/\\/g, '/').split('/').filter(Boolean).pop() ?? p,
-      category: 'default',
     };
+    selectedRulePresetId.value = null;
+    rememberRulePreset.value = true;
     initTags([]);
   }
   applyToSubfolders.value = false;
@@ -127,37 +142,30 @@ const collectAllSubdirs = async (path: string): Promise<string[]> => {
   return result;
 };
 
-/// 確保某個路徑在 DB 有 row，並設定它的顯示名稱與類別。
+/// 確保某個路徑在 DB 有 row，並設定它的顯示名稱。
 /// 對「主路徑」我們會用使用者填的 name；對自動帶入的子目錄則沿用 file_name。
-const saveFolderCategory = async (
+const saveTrackedItem = async (
   path: string,
   displayName: string,
-  category: string,
 ): Promise<Item> => {
   const item = await api.quickImportItem(path);
   if (item.name !== displayName) {
     await api.setItemDisplayName(item.id, displayName);
   }
-  if ((item.category ?? 'default') !== category) {
-    await api.setItemCategory(item.id, category);
-  }
-  return { ...item, name: displayName, category };
+  return { ...item, name: displayName };
 };
 
 const getFolderDisplayName = (path: string): string => (
   path.replace(/\\/g, '/').split('/').filter(Boolean).pop() ?? path
 );
 
-const applySubfolderCategories = async (
-  subdirs: string[],
-  category: string,
-): Promise<Item[]> => {
+const trackSubfolders = async (subdirs: string[]): Promise<Item[]> => {
   if (!applyToSubfolders.value) return [];
 
   const result: Item[] = [];
   for (const subPath of subdirs) {
-    progressLabel.value = `套用子資料夾：${getFolderDisplayName(subPath)}`;
-    result.push(await saveFolderCategory(subPath, getFolderDisplayName(subPath), category));
+    progressLabel.value = `加入子資料夾：${getFolderDisplayName(subPath)}`;
+    result.push(await saveTrackedItem(subPath, getFolderDisplayName(subPath)));
     progressDone.value += 1;
   }
   return result;
@@ -183,16 +191,13 @@ const collectAllSubfiles = async (parentPath: string, subdirs: string[]): Promis
   return result;
 };
 
-const applySubfileCategories = async (
-  subfiles: FileItem[],
-  category: string,
-): Promise<Item[]> => {
+const trackSubfiles = async (subfiles: FileItem[]): Promise<Item[]> => {
   if (!applyToSubfiles.value) return [];
 
   const result: Item[] = [];
   for (const file of subfiles) {
-    progressLabel.value = `套用子檔案：${file.name}`;
-    result.push(await saveFolderCategory(file.path, file.name, category));
+    progressLabel.value = `加入子檔案：${file.name}`;
+    result.push(await saveTrackedItem(file.path, file.name));
     progressDone.value += 1;
   }
   return result;
@@ -203,7 +208,7 @@ const refreshFolderState = async () => {
   emit('folderCreated');
 };
 
-const runRulesForCategory = async (targets: Item[], selectedType: ReturnType<typeof getTypeConfig>) => {
+const runRulesForPreset = async (targets: Item[], selectedType: ItemType) => {
   if (!selectedType.tagRules?.length) return;
 
   try {
@@ -219,12 +224,12 @@ const runRulesForCategory = async (targets: Item[], selectedType: ReturnType<typ
 };
 
 const submitFolderModal = async () => {
-  const { path, name, category } = editFolder.value;
+  const { path, name } = editFolder.value;
   if (!path || !name || isSavingFolder.value) return;
   isSavingFolder.value = true;
   progressDone.value = 0;
   progressTotal.value = 1;
-  progressLabel.value = '準備套用類別...';
+  progressLabel.value = '準備加入知識庫...';
   try {
     const subdirs = applyToSubfolders.value || applyToSubfiles.value
       ? await collectAllSubdirs(path)
@@ -234,23 +239,36 @@ const submitFolderModal = async () => {
       : [];
 
     await loadItemTypes();
-    const selectedType = getTypeConfig(category);
-    const categoryTargetCount = 1 + (applyToSubfolders.value ? subdirs.length : 0) + (applyToSubfiles.value ? subfiles.length : 0);
-    const ruleTargetCount = selectedType.tagRules?.length ? categoryTargetCount : 0;
-    progressTotal.value = categoryTargetCount + ruleTargetCount;
+    const selectedType = selectedRulePreset.value;
+    const trackedTargetCount = 1 + (applyToSubfolders.value ? subdirs.length : 0) + (applyToSubfiles.value ? subfiles.length : 0);
+    const ruleTargetCount = selectedType?.tagRules?.length ? trackedTargetCount : 0;
+    progressTotal.value = trackedTargetCount + ruleTargetCount;
 
-    progressLabel.value = `套用目前資料夾：${name.trim()}`;
-    const saved = await saveFolderCategory(path, name.trim(), category);
+    progressLabel.value = `加入目前資料夾：${name.trim()}`;
+    const saved = await saveTrackedItem(path, name.trim());
     progressDone.value += 1;
     folderInDb.value = { id: saved.id };
 
-    const subfolderItems = await applySubfolderCategories(subdirs, category);
-    const subfileItems = await applySubfileCategories(subfiles, category);
+    const subfolderItems = await trackSubfolders(subdirs);
+    const subfileItems = await trackSubfiles(subfiles);
     const allTargets = [saved, ...subfolderItems, ...subfileItems];
+
+    if (selectedType && rememberRulePreset.value) {
+      progressLabel.value = '儲存資料夾預設規則集...';
+      await api.setFolderRulePreset({
+        folderItemId: saved.id,
+        presetTypeId: selectedType.id,
+        applyToSubfolders: applyToSubfolders.value,
+        applyToFiles: applyToSubfiles.value,
+        fileExtensions: subfileExtensions.value,
+      });
+    } else {
+      await api.clearFolderRulePreset(saved.id);
+    }
 
     progressLabel.value = '更新畫面狀態...';
     await refreshFolderState();
-    await runRulesForCategory(allTargets, selectedType);
+    if (selectedType) await runRulesForPreset(allTargets, selectedType);
     modalPhase.value = 'tags';
   } catch (e) {
     showToast('操作失敗: ' + String(e), 'error');
@@ -269,10 +287,16 @@ onUnmounted(() => {
 
 const dbFolders = ref<Item[]>([]);
 const folderByPath = computed(() => new Map(dbFolders.value.map(f => [f.path, f])));
-const hasFolderCategory = (path: string): boolean => {
-  const f = folderByPath.value.get(path);
-  return !!f?.category && f.category !== 'default';
-};
+const folderRulePresetByItemId = computed(() => new Map(folderRulePresets.value.map(p => [p.folderItemId, p])));
+const folderRulePresetByPath = computed(() => {
+  const entries: Array<[string, FolderRulePreset]> = [];
+  for (const folder of dbFolders.value) {
+    const preset = folderRulePresetByItemId.value.get(folder.id);
+    if (preset) entries.push([folder.path, preset]);
+  }
+  return new Map(entries);
+});
+const hasFolderRulePreset = (path: string): boolean => folderRulePresetByPath.value.has(path);
 provide('folderByPath', folderByPath);
 const { applyRulesForTarget } = useFolderRuleActions(
   undefined,
@@ -283,9 +307,10 @@ const { applyRulesForTarget } = useFolderRuleActions(
 
 const applyRulesFromCtx = async () => {
   const path = ctxMenu.value.path;
+  const preset = folderRulePresetByPath.value.get(path);
   await applyRulesForTarget({
     path,
-    category: folderByPath.value.get(path)?.category,
+    presetTypeId: preset?.presetTypeId,
   });
   emit('folderCreated');
 };
@@ -305,8 +330,12 @@ const openInExplorerFromCtx = async () => {
 };
 
 const loadDbFolders = async () => {
-  const page = await api.getItems(0, 9999, undefined, undefined, undefined, undefined, 'folder');
+  const [page, presets] = await Promise.all([
+    api.getItems(0, 9999, undefined, undefined, undefined, undefined, 'folder'),
+    api.getFolderRulePresets(),
+  ]);
   dbFolders.value = page.content;
+  folderRulePresets.value = presets;
 };
 
 const {
@@ -361,18 +390,18 @@ onMounted(() => {
     >
       <div class="ctx-item" @click="enterFolderFromCtx">進入資料夾</div>
       <div class="ctx-divider"></div>
-      <div class="ctx-item" @click="openModifyTypeFromCtx">{{ hasFolderCategory(ctxMenu.path) ? '修改類別' : '新增類別' }}</div>
-      <div v-if="hasFolderCategory(ctxMenu.path)" class="ctx-item" @click="applyRulesFromCtx">重新套用類別</div>
+      <div class="ctx-item" @click="openModifyTypeFromCtx">{{ folderByPath.has(ctxMenu.path) ? '編輯標籤' : '加入知識庫' }}</div>
+      <div v-if="hasFolderRulePreset(ctxMenu.path)" class="ctx-item" @click="applyRulesFromCtx">套用既有標籤規則</div>
       <div class="ctx-divider"></div>
       <div class="ctx-item" @click="openInExplorerFromCtx">在檔案總管中顯示</div>
       <div class="ctx-item ctx-danger" @click="untrackFromCtx">移除追蹤記錄</div>
     </div>
 
-    <!-- 修改類型 / 加入知識庫 Modal -->
+    <!-- 加入知識庫 / 設定標籤 Modal -->
     <div v-if="showFolderModal" class="folder-modal-backdrop" @click.self="!isSavingFolder && (showFolderModal = false)">
       <div class="folder-modal glass-panel">
         <template v-if="modalPhase === 'edit'">
-          <h3>{{ folderInDb ? '修改類別' : '加入知識庫' }}</h3>
+          <h3>{{ folderInDb ? '編輯資料夾標籤' : '加入知識庫' }}</h3>
           <div class="folder-field">
             <label>路徑</label>
             <span class="path-text">{{ editFolder.path }}</span>
@@ -382,20 +411,26 @@ onMounted(() => {
             <input v-model="editFolder.name" class="folder-input" placeholder="顯示名稱" :disabled="isSavingFolder" />
           </div>
           <div class="folder-field">
-            <label>類別</label>
-            <select v-model="editFolder.category" class="folder-input" :disabled="isSavingFolder">
-              <option v-for="t in itemTypes" :key="t.name" :value="t.name">
+            <label>標籤規則集（選填）</label>
+            <select v-model="selectedRulePresetId" class="folder-input" :disabled="isSavingFolder">
+              <option :value="null">不使用規則集</option>
+              <option v-for="t in rulePresetOptions" :key="t.id" :value="t.id">
                 {{ t.icon }} {{ t.displayName }}
               </option>
             </select>
+            <p class="field-hint">只用來套用標籤規則，不會改變資料夾本身；資料夾仍是單純資料夾。</p>
           </div>
           <label class="apply-sub-check">
+            <input type="checkbox" v-model="rememberRulePreset" :disabled="isSavingFolder || selectedRulePresetId == null" />
+            記住為這個資料夾的預設標籤規則集
+          </label>
+          <label class="apply-sub-check">
             <input type="checkbox" v-model="applyToSubfolders" :disabled="isSavingFolder" />
-            套用至所有子資料夾
+            同時加入所有子資料夾
           </label>
           <label class="apply-sub-check">
             <input type="checkbox" v-model="applyToSubfiles" :disabled="isSavingFolder" />
-            套用至所有子檔案
+            同時加入所有子檔案
           </label>
           <div v-if="applyToSubfiles" class="folder-field subfile-extension-field">
             <label>子檔案副檔名</label>
@@ -612,6 +647,13 @@ onMounted(() => {
   font-family: inherit;
 }
 .folder-input:focus { border-color: var(--accent); }
+
+.field-hint {
+  margin: -6px 0 2px;
+  color: var(--text-tertiary);
+  font-size: 0.78rem;
+  line-height: 1.4;
+}
 
 .apply-sub-check {
   display: flex;

--- a/src/components/ThumbnailGridView.vue
+++ b/src/components/ThumbnailGridView.vue
@@ -252,8 +252,9 @@ const startRenameCtx = () => {
     >
       <template v-if="contextMenu.item?.isDir">
         <button class="ctx-item" @click="emit('dblclick', contextMenu.item!); hideContextMenu()">進入資料夾</button>
-        <button class="ctx-item" @click="emit('detail', contextMenu.item!); hideContextMenu()">{{ hasCategoryAssigned(contextMenu.item!, itemByPath) ? '修改類別' : '新增類別' }}</button>
-        <button class="ctx-item" @click="applyRulesForItem(contextMenu.item!)">重新套用類別</button>
+        <button v-if="contextMenu.item && canRead(contextMenu.item)" class="ctx-item" @click="emit('read', contextMenu.item!); hideContextMenu()">開啟閱讀模式</button>
+        <button class="ctx-item" @click="emit('detail', contextMenu.item!); hideContextMenu()">編輯標籤</button>
+        <button class="ctx-item" @click="applyRulesForItem(contextMenu.item!)">套用標籤規則</button>
         <button class="ctx-item" @click="startRenameCtx">修改檔名</button>
         <div class="ctx-divider"></div>
         <button class="ctx-item ctx-danger" @click="emit('delete', contextMenu.item!); hideContextMenu()">移至資源回收筒</button>
@@ -261,7 +262,7 @@ const startRenameCtx = () => {
       <template v-else>
         <button class="ctx-item" @click="emit('detail', contextMenu.item!); hideContextMenu()">詳情/編輯標籤</button>
         <button class="ctx-item" @click="emit('addCategory', contextMenu.item!); hideContextMenu()">{{ hasCategoryAssigned(contextMenu.item!, itemByPath) ? '修改類別' : '新增類別' }}</button>
-        <button class="ctx-item" @click="applyRulesForItem(contextMenu.item!)">重新套用類別</button>
+        <button class="ctx-item" @click="applyRulesForItem(contextMenu.item!)">套用標籤規則</button>
         <button class="ctx-item" @click="startRenameCtx">修改檔名</button>
         <div class="ctx-divider"></div>
         <button class="ctx-item ctx-danger" @click="emit('delete', contextMenu.item!); hideContextMenu()">移至資源回收筒</button>

--- a/src/composables/useCategoryManage.ts
+++ b/src/composables/useCategoryManage.ts
@@ -111,7 +111,7 @@ export function useCategoryManage() {
 
     const deleteType = async (t: ItemType) => {
         if (t.isBuiltin) return;
-        if (!await confirmDialog(`確定刪除「${t.displayName}」類型？\n使用此類型的資料夾將重設為「一般資料夾」。`)) return;
+        if (!await confirmDialog(`確定刪除「${t.displayName}」規則集？\n已套用到項目的標籤不會自動移除；使用此規則集作為資料夾預設的綁定會被清除。`)) return;
         try {
             await api.deleteItemType(t.id);
             invalidate();

--- a/src/composables/useExternalChanges.test.ts
+++ b/src/composables/useExternalChanges.test.ts
@@ -66,20 +66,6 @@ const page = <T>(content: T[], totalPages = 1): Page<T> => ({
   size: content.length,
 });
 
-const comicType = {
-  id: 2,
-  name: 'comic',
-  icon: 'C',
-  displayName: 'Comic',
-  color: null,
-  example: '',
-  isBuiltin: false,
-  extensions: ['zip'],
-  tagRules: [
-    { name: 'zip rule', matchType: 'extension', pattern: 'zip', tagName: 'ZIP' },
-  ],
-};
-
 describe('computeExternalChanges', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -175,7 +161,7 @@ describe('useExternalChanges', () => {
     expect(externalChanges.changes.value).toEqual([]);
   });
 
-  it('asks to apply parent folder category when importing one untracked item', async () => {
+  it('imports one untracked item without inheriting parent folder category', async () => {
     apiMock.getItemByPath.mockResolvedValueOnce(dbItem({
       id: 10,
       path: 'C:/Library',
@@ -189,8 +175,6 @@ describe('useExternalChanges', () => {
       name: 'new.zip',
       category: 'default',
     }));
-    apiMock.getItemTypes.mockResolvedValueOnce([comicType]);
-    apiMock.applyRulesToItem.mockResolvedValueOnce({ added: 0, updated: 0, removed: 0, tagged: 1 });
     apiMock.listDirFiles.mockResolvedValueOnce([]);
     apiMock.getItems.mockResolvedValueOnce(page([]));
 
@@ -198,11 +182,11 @@ describe('useExternalChanges', () => {
 
     await externalChanges.importOne('C:/Library/new.zip');
 
-    expect(apiMock.getItemByPath).toHaveBeenCalledWith('C:/Library');
     expect(apiMock.quickImportItem).toHaveBeenCalledWith('C:/Library/new.zip');
-    expect(apiMock.setItemCategory).toHaveBeenCalledWith(20, 'comic');
-    expect(apiMock.getItemTypes).toHaveBeenCalled();
-    expect(apiMock.applyRulesToItem).toHaveBeenCalledWith(20, comicType.tagRules);
+    expect(apiMock.getItemByPath).not.toHaveBeenCalled();
+    expect(apiMock.setItemCategory).not.toHaveBeenCalled();
+    expect(apiMock.getItemTypes).not.toHaveBeenCalled();
+    expect(apiMock.applyRulesToItem).not.toHaveBeenCalled();
   });
 
   it('does not apply parent category when the parent has only the default category', async () => {

--- a/src/composables/useExternalChanges.ts
+++ b/src/composables/useExternalChanges.ts
@@ -1,5 +1,5 @@
 import { ref, computed } from 'vue';
-import { api, type FileItem, type Item, type TagRuleInput } from '../api';
+import { api, type FileItem, type Item } from '../api';
 import { pathKey } from '../utils/pathKey';
 import { useToast } from './useToast';
 
@@ -106,7 +106,7 @@ export function computeExternalChanges(
 }
 
 export function useExternalChanges(sourcePath: () => string | null) {
-  const { show, confirm } = useToast();
+  const { show } = useToast();
   const changes = ref<ExternalChange[]>([]);
   const isLoading = ref(false);
   const isFixing = ref(false);
@@ -121,66 +121,8 @@ export function useExternalChanges(sourcePath: () => string | null) {
 
   const changeKey = (change: ExternalChange) => `${change.kind}::${pathKey(change.path)}`;
 
-  const getParentCategory = async (path: string): Promise<{ path: string; name: string; category: string } | null> => {
-    const parent = parentDir(path);
-    if (!parent || parent === path) return null;
-    try {
-      const parentItem = await api.getItemByPath(parent);
-      if (!parentItem?.category || parentItem.category === 'default') return null;
-      return {
-        path: parent,
-        name: parentItem.name,
-        category: parentItem.category,
-      };
-    } catch (e) {
-      console.error(`[useExternalChanges] failed to load parent category: ${parent}`, e);
-      return null;
-    }
-  };
-
-  const shouldApplyParentCategory = async (
-    path: string,
-    decisions: Map<string, boolean>,
-  ): Promise<string | null> => {
-    const parent = await getParentCategory(path);
-    if (!parent) return null;
-
-    const key = `${pathKey(parent.path)}::${parent.category}`;
-    if (!decisions.has(key)) {
-      const apply = await confirm(
-        `「${parent.name}」已有「${parent.category}」類別。\n要把這個類別套用到匯入項目嗎？`
-      );
-      decisions.set(key, apply);
-    }
-    return decisions.get(key) ? parent.category : null;
-  };
-
-  const getCategoryTagRules = async (
-    category: string,
-    cache: Map<string, TagRuleInput[]>,
-  ): Promise<TagRuleInput[]> => {
-    if (cache.has(category)) return cache.get(category) ?? [];
-    const itemTypes = await api.getItemTypes();
-    const rules = itemTypes.find(type => type.name === category)?.tagRules ?? [];
-    cache.set(category, rules);
-    return rules;
-  };
-
-  const importWithOptionalParentCategory = async (
-    path: string,
-    decisions: Map<string, boolean>,
-    categoryRuleCache: Map<string, TagRuleInput[]> = new Map(),
-  ): Promise<boolean> => {
-    const category = await shouldApplyParentCategory(path, decisions);
-    const item = await api.quickImportItem(path);
-    if (!category) return false;
-
-    await api.setItemCategory(item.id, category);
-    const rules = await getCategoryTagRules(category, categoryRuleCache);
-    if (rules.length > 0) {
-      await api.applyRulesToItem(item.id, rules);
-    }
-    return true;
+  const importUntrackedItem = async (path: string): Promise<void> => {
+    await api.quickImportItem(path);
   };
 
   const refresh = async () => {
@@ -212,20 +154,11 @@ export function useExternalChanges(sourcePath: () => string | null) {
 
     let added = 0, removed = 0, updated = 0, errors = 0;
     const snapshot = [...changes.value];
-    const categoryDecisions = new Map<string, boolean>();
-    const categoryRuleCache = new Map<string, TagRuleInput[]>();
-
     try {
-      for (const change of snapshot) {
-        if (change.kind === 'untracked') {
-          await shouldApplyParentCategory(change.path, categoryDecisions);
-        }
-      }
-
       await runInBatches(snapshot, FIX_CONCURRENCY, async change => {
         try {
           if (change.kind === 'untracked') {
-            await importWithOptionalParentCategory(change.path, categoryDecisions, categoryRuleCache);
+            await importUntrackedItem(change.path);
             added++;
           } else if (change.kind === 'missing') {
             await api.untrackItem(change.path, { allowMissing: true });
@@ -260,9 +193,8 @@ export function useExternalChanges(sourcePath: () => string | null) {
   const importOne = async (path: string) => {
     isFixing.value = true;
     try {
-      const appliedCategory = await importWithOptionalParentCategory(path, new Map());
+      await importUntrackedItem(path);
       show('已匯入', 'success');
-      if (appliedCategory) show('已套用父資料夾類別', 'success');
       await refresh();
     } catch (e) {
       console.error('[useExternalChanges] importOne failed', e);

--- a/src/composables/useFolderRuleActions.ts
+++ b/src/composables/useFolderRuleActions.ts
@@ -5,6 +5,7 @@ type ToastType = 'success' | 'error' | 'info';
 type RuleTarget = {
   path: string;
   category?: string | null;
+  presetTypeId?: number | null;
 };
 
 export function useFolderRuleActions(
@@ -27,15 +28,28 @@ export function useFolderRuleActions(
       }
     }
 
-    const category = target.category ?? dbItem.category ?? 'default';
-    const type = itemTypes().find(t => t.name === category);
+    const types = itemTypes();
+    let type = target.presetTypeId != null
+      ? types.find(t => t.id === target.presetTypeId)
+      : undefined;
+
+    if (!type && dbItem.itemType === 'folder') {
+      const preset = await api.getFolderRulePreset(dbItem.id);
+      if (preset) type = types.find(t => t.id === preset.presetTypeId);
+    }
+
+    if (!type && dbItem.itemType !== 'folder') {
+      const presetName = target.category ?? dbItem.category ?? 'default';
+      type = types.find(t => t.name === presetName);
+    }
+
     if (!type?.tagRules?.length) {
-      showToast('此類別沒有設定掃描規則', 'info');
+      showToast(dbItem.itemType === 'folder' ? '此資料夾尚未設定預設標籤規則集' : '此項目沒有可套用的標籤規則集', 'info');
       return;
     }
 
     try {
-      // 「重新套用類別」語意：只對該 item 自己跑目前類別規則，不遞迴、不碰子層、不掃 FS。
+      // 「套用標籤規則集」語意：只對該 item 自己跑目前規則，不遞迴、不碰子層、不掃 FS。
       // 想對整個目錄樹批次掃描請走「掃描精靈」（applyTagScan）。
       const result = await api.applyRulesToItem(dbItem.id, type.tagRules);
       showToast(`已套用 ${result.tagged} 個標籤`, 'success');

--- a/src/composables/useThumbnailLoader.ts
+++ b/src/composables/useThumbnailLoader.ts
@@ -128,7 +128,7 @@ export function useThumbnailLoader() {
   const getIcon = (item: FileItem, itemByPath: Map<string, Item>): string => {
     const dbItem = getDbItem(item, itemByPath);
     if (item.isDir) {
-      return getTypeConfig(dbItem?.category).icon;
+      return '📁';
     }
     if (hasUserCategory(dbItem)) {
       return getTypeConfig(dbItem!.category).icon;
@@ -148,8 +148,7 @@ export function useThumbnailLoader() {
   const getItemType = (item: FileItem, itemByPath: Map<string, Item>): string => {
     const dbItem = getDbItem(item, itemByPath);
     if (item.isDir) {
-      if (dbItem) return getTypeConfig(dbItem.category).displayName;
-      return '目錄';
+      return dbItem ? '已追蹤資料夾' : '資料夾';
     }
     if (hasUserCategory(dbItem)) {
       return getTypeConfig(dbItem!.category).displayName;
@@ -160,7 +159,7 @@ export function useThumbnailLoader() {
   const getTypeColor = (item: FileItem, itemByPath: Map<string, Item>): string | null => {
     const dbItem = getDbItem(item, itemByPath);
     if (item.isDir) {
-      return getTypeConfig(dbItem?.category).color ?? null;
+      return null;
     }
     if (hasUserCategory(dbItem)) {
       return getTypeConfig(dbItem!.category).color ?? null;

--- a/src/utils/readableItem.test.ts
+++ b/src/utils/readableItem.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { FileItem, Item } from '../api';
-import { isComicFolderItem, isReadableArchiveItem, isReadableFileItem } from './readableItem';
+import { isReadableArchiveItem, isReadableFileItem, isReadableFolderItem } from './readableItem';
 
 const fileItem = (overrides: Partial<FileItem> = {}): FileItem => ({
   name: 'book.zip',
@@ -38,18 +38,19 @@ describe('readableItem', () => {
     expect(isReadableArchiveItem(fileItem({ extension: 'rar' }))).toBe(false);
   });
 
-  it('treats only comic-category folders as readable folders', () => {
-    expect(isComicFolderItem(dbItem({ itemType: 'folder', category: 'comic' }))).toBe(true);
-    expect(isComicFolderItem(dbItem({ itemType: 'folder', category: 'default' }))).toBe(false);
-    expect(isComicFolderItem(dbItem({ itemType: 'file', category: 'comic' }))).toBe(false);
+  it('treats physical folders as readable candidates regardless of category', () => {
+    expect(isReadableFolderItem(dbItem({ itemType: 'folder', category: 'comic' }))).toBe(true);
+    expect(isReadableFolderItem(dbItem({ itemType: 'folder', category: 'default' }))).toBe(true);
+    expect(isReadableFolderItem(dbItem({ itemType: 'folder', category: null }))).toBe(true);
+    expect(isReadableFolderItem(dbItem({ itemType: 'file', category: 'comic' }))).toBe(false);
   });
 
-  it('shows the read action only for archives or comic folders', () => {
+  it('shows the read action for archives or tracked folders', () => {
     expect(isReadableFileItem(fileItem({ extension: 'zip' }))).toBe(true);
     expect(isReadableFileItem(fileItem({ extension: 'txt' }))).toBe(false);
     expect(isReadableFileItem(
       fileItem({ name: 'Series', path: 'C:/Library/Series', isDir: true, extension: null }),
-      dbItem({ itemType: 'folder', category: 'comic' }),
+      dbItem({ itemType: 'folder', category: 'default' }),
     )).toBe(true);
   });
 });

--- a/src/utils/readableItem.ts
+++ b/src/utils/readableItem.ts
@@ -6,11 +6,14 @@ export const READABLE_IMAGE_EXTS = new Set(['jpg', 'jpeg', 'png', 'gif', 'webp',
 export const isReadableArchiveItem = (item: FileItem): boolean =>
   !item.isDir && READABLE_ARCHIVE_EXTS.has(item.extension?.toLowerCase() ?? '');
 
-export const isComicFolderItem = (dbItem?: Item | null): boolean =>
-  dbItem?.itemType === 'folder' && dbItem.category === 'comic';
+export const isReadableFolderItem = (dbItem?: Item | null): boolean =>
+  dbItem?.itemType === 'folder';
+
+/** @deprecated Folder readability is no longer tied to the legacy comic category. */
+export const isComicFolderItem = isReadableFolderItem;
 
 export const isReadableFileItem = (item: FileItem, dbItem?: Item | null): boolean =>
-  isReadableArchiveItem(item) || (item.isDir && isComicFolderItem(dbItem));
+  isReadableArchiveItem(item) || (item.isDir && (!dbItem || isReadableFolderItem(dbItem)));
 
 export const isReadableImageFile = (item: FileItem): boolean =>
   !item.isDir && READABLE_IMAGE_EXTS.has(item.extension?.toLowerCase() ?? '');


### PR DESCRIPTION
## 修改方向

這個分支把「資料夾」從 category/type 語意中拆出來，並把設定/規則集管理改成更清楚的設定中心與自動化工作台：

- 資料夾只保留物理事實：`itemType` 為 `file | folder`。
- tags 才承載語意，例如漫畫、作者、系列、待整理。
- rules / presets 定位為自動化輔助，不再回頭污染資料夾本質。
- 新增獨立的「資料夾預設標籤規則集」資料模型，避免再用 category/type 記資料夾規則。
- 重新設計「設定」與「標籤規則集管理」，讓規則集被理解成自動化模板，而不是分類/資料夾類型。

## 主要變更

1. 資料夾去類型化
- 資料夾 reader 判斷改成內容能力：可讀資料夾可以進 reader。
- `isComicFolderItem` 保留但標示 deprecated，改由可讀能力判斷。
- 雙擊資料夾仍優先導航進資料夾，不會因為可讀就直接開 reader。

2. 獨立資料夾預設標籤規則集
- 新增 `folder_rule_presets` DB table。
- 新增 Tauri commands：
  - `get_folder_rule_presets`
  - `get_folder_rule_preset`
  - `set_folder_rule_preset`
  - `clear_folder_rule_preset`
- 新增 frontend API wrapper。
- `SourcePanel.vue`：加入/編輯資料夾時可選規則集，並可勾選「記住為這個資料夾的預設標籤規則集」。
- `FolderDetailModal.vue`：新增「自動化」區塊，可設定、清除、立即套用 preset。
- `useFolderRuleActions.ts`：資料夾套規則時優先讀 `folder_rule_presets`；非資料夾仍保留既有 fallback。
- 刪除規則集時同步清除資料夾 preset 綁定。

3. UI 文案與操作補修
- `ThumbnailGridView.vue`：可讀資料夾右鍵補「開啟閱讀模式」。
- `ComicSlideReader.vue`：`COMIC FOLDER` 改成 `FOLDER READER`。
- `useCategoryManage.ts`：刪除規則集確認文案改成規則集語意，不再說「資料夾類型」。

4. 設定與規則集工作台 redesign
- `SettingsPanel.vue`
  - 從單欄清單改成「設定中心」。
  - 新增 hero/header、設定分類 rail、卡片式內容。
  - 分成「標籤與自動化」「外觀與閱讀密度」「系統與診斷」。
- `CategoryManageModal.vue`
  - 改成「標籤規則集工作台」。
  - 加入說明 header、摘要 pills、左側規則集庫、右側編輯區。
- `CategoryList.vue`
  - 改成規則集庫，顯示副檔名數、規則數、內建/自訂狀態。
- `CategoryEditor.vue`
  - 改成分段卡片：基本識別、適用範圍、自動標記規則、即時測試。
  - 修正規則列/副檔名輸入 overflow 風險。
  - 移除會遮住欄位的 sticky save bar。

## 回家測試重點

- SourcePanel 右鍵資料夾 → 加入知識庫 / 編輯資料夾標籤：
  - 選規則集。
  - 勾「記住為這個資料夾的預設標籤規則集」。
  - 關掉重開後確認 preset 會回填。
- FolderDetailModal：
  - 設定 preset。
  - 立即套用。
  - 清除 preset。
- Thumbnail grid：
  - 可讀資料夾右鍵應出現「開啟閱讀模式」。
- 雙擊資料夾：
  - 應仍然優先導航進資料夾，不應直接開 reader。
- Settings：
  - 三個設定分區能正常切換。
  - 「管理規則集」能打開工作台。
  - 新增/編輯/刪除規則集、增減副檔名、增減規則、即時測試都能操作。
- 全域 UI 文案：
  - 不應再把資料夾講成「類型」或「漫畫資料夾」。

## 驗證

第一輪資料夾/規則集改動：
- `npm run build`：通過
- `npm test`：通過，27 tests passed
- `cd src-tauri && cargo test`：通過，18 tests passed
- `git diff --check`：通過，exit 0
  - 僅有 Rust 檔案 LF/CRLF warning，不是 blocking error。
- `gitnexus_detect_changes(scope=all)`：CRITICAL
  - 預期風險；本分支刻意碰到 `init_db`、Tauri command registration、SourcePanel、資料夾去類型化分支。
  - 已補 DB 測試：`init_db_creates_folder_rule_preset_bindings_table`。

設定/規則集 redesign 追加驗證：
- `npm run lint:css`：通過
- `npm run build`：通過
- `npm test`：通過，27 tests passed
- `git diff --check`：通過
- 舊語意文案搜尋：通過，0 matches
- `gitnexus_detect_changes(scope=all)`：LOW，affected_count 0，affected_processes empty
- Browser layout smoke：通過
  - 注意：browser smoke 是 Vite browser 環境，不是 Tauri runtime；console 中 `invoke` missing 是預期限制，真正新增/編輯/刪除規則集仍需在 Tauri app 中用家裡資料測。

## Workflow

- 資料夾/規則集：`feature-dev-2026-06-15T02-50-19-726Z` 已完成。
- 設定/規則集 redesign：`feature-dev-2026-06-15T03-54-41-568Z` 已完成。

## 備註

- 這個 PR 先維持 Draft，等家裡資料測試 OK 後再轉正式 review / merge。
